### PR TITLE
Remove nextId in simple data classes. Add ID ctor

### DIFF
--- a/src/datastore/souvenir.cpp
+++ b/src/datastore/souvenir.cpp
@@ -62,3 +62,17 @@ void Souvenir::setPrice(double price)
 {
     if(price >= 0.0) { m_price = price; }
 }
+
+/**
+ * Private constructor used by @a Database through friend class
+ * association. This sets the id, name, and price of the souvenir.
+ *
+ * @param id Souvenir ID
+ * @param name Souvenir name
+ * @param price Souvenir price
+ */
+Souvenir::Souvenir(int id, const std::string& name, double price)
+    : Souvenir(name, price)
+{
+    m_id = id;
+}

--- a/src/datastore/souvenir.hpp
+++ b/src/datastore/souvenir.hpp
@@ -32,6 +32,9 @@ public:
     bool hidden = true;
 
 private:
+    /* Constructors */
+    Souvenir(int id, const std::string&name, double price);
+
     /* Data */
     int m_id = -1;
     std::string m_name = "invalid";

--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -7,9 +7,6 @@ const std::string Stadium::SURFACE_STRING[] = {"Grass", "AstroTurg GameDay Grass
 const std::string Stadium::TYPOLOGY_STRING[] = {"Retro Modern", "Retro Classic", "Jewelbox",
                                                 "Modern", "Contemporary", "Multipurpose"};
 
-/* Static variables */
-int Stadium::nextId = 0;
-
 /**
  * Constructs an invalid stadium.
  */
@@ -29,10 +26,7 @@ Stadium::Stadium()
  * @param location Stadium location
  */
 Stadium::Stadium(const std::string& name, const std::string& location)
-    : m_id(nextId)
 {
-    nextId++;
-
     setName(name);
     setLocation(location);
 }

--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -14,10 +14,9 @@ Stadium::Stadium()
 {}
 
 /**
- * Constructs a stadium given a name and location. The ID of this
- * stadium will be set to @a nextId, then @a nextID is incremented
- * after. The rest of the data is initialized to -1 (for integers)
- * or the first item in the enum.
+ * Constructs a stadium given a name and location. ID and integer
+ * data will be defaulted to -1. Enum data is set to the first item
+ * in the enum.
  *
  * If @a name is an empty string, the name is set to "invalid".
  * If @a location is an empty string, the location is set to "invalid".

--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -158,3 +158,17 @@ Souvenir& Stadium::findSouvenir(int id)
 {
     return m_souvenirs[id];
 }
+
+/**
+ * Private constructor used by @a Database through friend class
+ * association. This sets the id, name, and location of the Stadium.
+ *
+ * @param id Stadium id
+ * @param name Stadium name
+ * @param location Stadium location
+ */
+Stadium::Stadium(int id, const std::string& name, const std::string& location)
+    : Stadium(name, location)
+{
+    m_id = id;
+}

--- a/src/datastore/stadium.hpp
+++ b/src/datastore/stadium.hpp
@@ -17,7 +17,7 @@
 class Stadium
 {
 public:
-    friend class DataStore;
+    friend class Database;
 
     /* Enum types */
     enum Roof { RETRACTABLE, OPEN, FIXED };
@@ -60,10 +60,7 @@ public:
     Typology typology = Typology::RETROMODERN;
 
 private:
-    /* Static variables */
-    static int nextId;
-
-    /* Stadium information */
+    /* Data */
     int m_id = -1;
     std::string m_name = "invalid";
     std::string m_location = "invalid";

--- a/src/datastore/stadium.hpp
+++ b/src/datastore/stadium.hpp
@@ -13,6 +13,11 @@
  * Enum classes are available for information about the stadium's
  * architecture. There is also static variables in the class to
  * convert an enum type to an associated string.
+ *
+ * Note:
+ * All stadiums have their IDs defaulted to -1. The only way for a
+ * stadium to have a valid ID is for it to be created by the
+ * @a Database class. This is why @a Database is a friend class.
  */
 class Stadium
 {

--- a/src/datastore/stadium.hpp
+++ b/src/datastore/stadium.hpp
@@ -65,6 +65,9 @@ public:
     Typology typology = Typology::RETROMODERN;
 
 private:
+    /* Constructors */
+    Stadium(int id, const std::string& name, const std::string& location);
+
     /* Data */
     int m_id = -1;
     std::string m_name = "invalid";

--- a/src/datastore/team.cpp
+++ b/src/datastore/team.cpp
@@ -10,8 +10,9 @@ Team::Team()
 {}
 
 /**
- * Constructs a team given a name and league. The ID of this team
- * will be set to @a nextId, then @a nextId is incremented after.
+ * Constructs a team given a name and league. ID data will be
+ * defaulted to -1. Enum data is set to the first item in the enum.
+ *
  * If @a name is an empty string, the team's name is set to "invalid".
  *
  * The stadium ID is set to -1 to indicate that the team is not

--- a/src/datastore/team.cpp
+++ b/src/datastore/team.cpp
@@ -61,3 +61,17 @@ void Team::setName(const std::string& name)
 {
     if(!name.empty()) { m_name = name; }
 }
+
+/**
+ * Private constructor used by @a Database through friend class
+ * association. This sets the id, name, and league of the team.
+ *
+ * @param id Team ID
+ * @param name Team name
+ * @param leag Team's league
+ */
+Team::Team(int id, const std::string& name, League leag)
+    : Team(name, leag)
+{
+    m_id = id;
+}

--- a/src/datastore/team.cpp
+++ b/src/datastore/team.cpp
@@ -3,9 +3,6 @@
 /* Enum to strings */
 const std::string Team::LEAGUE_STRING[] = {"National", "American"};
 
-/* Static variables */
-int Team::nextId = 0;
-
 /**
  * Constructs an invalid team.
  */
@@ -24,10 +21,8 @@ Team::Team()
  * @param leag Team's league
  */
 Team::Team(const std::string& name, League leag)
-    : league(leag), m_id(nextId)
+    : league(leag)
 {
-    nextId++;
-
     setName(name);
 }
 

--- a/src/datastore/team.hpp
+++ b/src/datastore/team.hpp
@@ -46,6 +46,9 @@ public:
     League league;
 
 private:
+    /* Constructors */
+    Team(int id, const std::string& name, League);
+
     /* Data */
     int m_id = -1;
     int m_stadiumId = -1;

--- a/src/datastore/team.hpp
+++ b/src/datastore/team.hpp
@@ -15,7 +15,7 @@
 class Team
 {
 public:
-    friend class DataStore;
+    friend class Database;
 
     /* Enum types */
     enum League { NATIONAL, AMERICAN };
@@ -41,9 +41,6 @@ public:
     League league;
 
 private:
-    /* Static variables */
-    static int nextId;
-
     /* Data */
     int m_id = -1;
     int m_stadiumId = -1;

--- a/src/datastore/team.hpp
+++ b/src/datastore/team.hpp
@@ -11,6 +11,11 @@
  *
  * A team with a stadium ID of -1 means it doesn't reside
  * in a stadium.
+ *
+ * Note:
+ * All teams have their IDs defaulted to -1. The only way for a
+ * team to have a valid ID is for it to be created by the
+ * @a Database class. This is why @a Database is a friend class.
  */
 class Team
 {


### PR DESCRIPTION
### Key features
* `Team` and `Stadium` IDs are always defaulted to `-1`. This way the only valid objects are created through `Database`.
* Private constructor for `Database` to use for setting the ID of the classes

### Future Improvements
* none

### Notes
none