### PR TITLE
Replace normal arrays with std::array

### DIFF
--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -1,11 +1,11 @@
 #include "stadium.hpp"
 
 /* Enum to strings */
-const std::string Stadium::ROOF_STRING[] = {"Rectractable", "Open", "Fixed"};
-const std::string Stadium::SURFACE_STRING[] = {"Grass", "AstroTurg GameDay Grass",
-                                               "AstroTurf GameDay Grass 3D"};
-const std::string Stadium::TYPOLOGY_STRING[] = {"Retro Modern", "Retro Classic", "Jewelbox",
-                                                "Modern", "Contemporary", "Multipurpose"};
+const std::array<std::string,3> Stadium::ROOF_STRING = {"Rectractable", "Open", "Fixed"};
+const std::array<std::string,3> SURFACE_STRING = {"Grass", "AstroTurg GameDay Grass",
+                                                  "AstroTurf GameDay Grass 3D"};
+const std::array<std::string,6> TYPOLOGY_STRING = {"Retro Modern", "Retro Classic", "Jewelbox",
+                                                   "Modern", "Contemporary", "Multipurpose"};
 
 /**
  * Constructs an invalid stadium.

--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -2,10 +2,10 @@
 
 /* Enum to strings */
 const std::array<std::string,3> Stadium::ROOF_STRING = {"Rectractable", "Open", "Fixed"};
-const std::array<std::string,3> SURFACE_STRING = {"Grass", "AstroTurg GameDay Grass",
-                                                  "AstroTurf GameDay Grass 3D"};
-const std::array<std::string,6> TYPOLOGY_STRING = {"Retro Modern", "Retro Classic", "Jewelbox",
-                                                   "Modern", "Contemporary", "Multipurpose"};
+const std::array<std::string,3> Stadium::SURFACE_STRING = {"Grass", "AstroTurg GameDay Grass",
+                                                           "AstroTurf GameDay Grass 3D"};
+const std::array<std::string,6> Stadium::TYPOLOGY_STRING = {"Retro Modern", "Retro Classic", "Jewelbox",
+                                                            "Modern", "Contemporary", "Multipurpose"};
 
 /**
  * Constructs an invalid stadium.

--- a/src/datastore/stadium.hpp
+++ b/src/datastore/stadium.hpp
@@ -2,6 +2,7 @@
 #include "souvenir.hpp"
 #include <map>
 #include <vector>
+#include <array>
 
 /**
  * @class Stadium class
@@ -30,9 +31,9 @@ public:
     enum Typology { RETROMODERN, RETROCLASSIC, JEWELBOX, MODERN, CONTEMPORARY, MULTIPURPOSE };
 
     /* Enum to strings */
-    static const std::string ROOF_STRING[];
-    static const std::string SURFACE_STRING[];
-    static const std::string TYPOLOGY_STRING[];
+    static const std::array<std::string,3> ROOF_STRING;
+    static const std::array<std::string,3> SURFACE_STRING;
+    static const std::array<std::string,6> TYPOLOGY_STRING;
 
     /* Constructors */
     Stadium();

--- a/src/datastore/team.cpp
+++ b/src/datastore/team.cpp
@@ -1,7 +1,7 @@
 #include "team.hpp"
 
 /* Enum to strings */
-const std::string Team::LEAGUE_STRING[] = {"National", "American"};
+const std::array<std::string,2> LEAGUE_STRING = {"National", "American"};
 
 /**
  * Constructs an invalid team.

--- a/src/datastore/team.cpp
+++ b/src/datastore/team.cpp
@@ -1,7 +1,7 @@
 #include "team.hpp"
 
 /* Enum to strings */
-const std::array<std::string,2> LEAGUE_STRING = {"National", "American"};
+const std::array<std::string,2> Team::LEAGUE_STRING = {"National", "American"};
 
 /**
  * Constructs an invalid team.

--- a/src/datastore/team.hpp
+++ b/src/datastore/team.hpp
@@ -26,7 +26,7 @@ public:
     enum League { NATIONAL, AMERICAN };
 
     /* Enum to strings */
-    static const std::string LEAGUE_STRING[];
+    static const std::array<std::string,2> LEAGUE_STRING;
 
     /* Constructors */
     Team();


### PR DESCRIPTION
### Key features
* Replace normal *enum to string* arrays with `std::array`

### Future Improvements
* none

### Notes
none