### PR TITLE
Parser Bug Fix

### DIFF
--- a/src/utils/parser.cpp
+++ b/src/utils/parser.cpp
@@ -66,7 +66,7 @@ std::vector<std::vector<std::string>> loadData(const std::string& path)
     while (!infile.eof())
     {
         std::getline(infile, line);
-        if (line.front() == '#' || line.front() == ' ' || line.empty()){continue;}
+        if (line.empty() || line.front() == '#' || line.front() == ' '){continue;}
 
         std::vector<std::string> columns;
 


### PR DESCRIPTION
Closes #(issue)

### Key features
* Fixed a bug where the getline() function reads an empty line and the first() function calls abort after attempting to read the empty line

### Future Improvements
* none

### Notes
none