### PR TITLE
Object ID reference switch

### DIFF
--- a/src/datastore/database.cpp
+++ b/src/datastore/database.cpp
@@ -45,11 +45,11 @@ void Database::loadFromFile(const std::string& filepath)
         tempTypology = database->getEnumValue(Stadium::TYPOLOGY_STRING,team[11], Stadium::Typology::MODERN);
 
         // Initializing a new Team class
-        Team tempTeam(std::stoi(team[0]), std::stoi(team[3]), team[1], tempLeague);
+        Team tempTeam(std::stoi(team[0]), team[1], tempLeague);
         // Set's deleted bool
         tempTeam.hidden = std::stoi(team[2]);
         // Initializing a new Stadium class
-        Stadium tempStadium(std::stoi(team[3]), team[4], team[6], std::stoi(team[5]),std::stoi(team[9]),
+        Stadium tempStadium(std::stoi(team[3]), std::stoi(team[0]), team[4], team[6], std::stoi(team[5]),std::stoi(team[9]),
                             std::stoi(team[10]), tempRoof, tempSurface, tempTypology);
         // Souvenir index starts at 14 for each team, reseting to 14 here
         // Used to traverser through souvenirs
@@ -140,8 +140,8 @@ std::vector<Stadium> Database::getStadiumsVector()
 {
     std::vector<Stadium> vec;
 
-    for(auto team : teams)
-        vec.push_back(stadiums[team.getStadiumId()]);
+    for(auto stadium : stadiums)
+        vec.push_back(stadium);
 
     return vec;
 }
@@ -188,7 +188,7 @@ void Database::saveToFile(const std::string& path)
         columns.push_back(std::to_string(teamVect[i].getId()));
         columns.push_back(teamVect[i].getName());
         columns.push_back(std::to_string(teamVect[i].hidden));
-        columns.push_back(std::to_string(teamVect[i].getStadiumId()));
+        columns.push_back(std::to_string(stadiumVect[i].getId()));
         columns.push_back(stadiumVect[i].getName());
         columns.push_back(std::to_string(stadiumVect[i].getSeatCap()));
         columns.push_back(stadiumVect[i].getLocation());

--- a/src/datastore/souvenir.cpp
+++ b/src/datastore/souvenir.cpp
@@ -1,32 +1,10 @@
 #include "souvenir.hpp"
 
 /**
- * Constructs a souvenir that is unattached from a stadium.
- * To add it to a stadium, use @a Stadium::addSouvenir.
- *
- * An object created by this should not be used in a stadium
- * unless the name and price has been changed; otherwise, both
- * will be initialized to "invalid" and -1 respectively.
+ * Constructs an invalid souvenir.
  */
 Souvenir::Souvenir()
 {}
-
-/**
- * Constructs a souvenir given a name and price. If @a name is
- * an empty string, the souvenir's name becomes "invalid". If
- * @a price is negative, the souvenir's price becomes -1.
- *
- * This souvenir is not attached to a stadium because its
- * ID is -1. To add it to a stadium, use @a Stadium::addSouvenir.
- *
- * @param name Souvenir name
- * @param price Souvenir price
- */
-Souvenir::Souvenir(const std::string& name, double price)
-{
-    setName(name);
-    setPrice(price);
-}
 
 int Souvenir::getId() const
 {
@@ -64,7 +42,7 @@ void Souvenir::setPrice(double price)
 }
 
 /**
- * Private constructor used by @a Database through friend class
+ * Private constructor used by @a Stadium through friend class
  * association. This sets the id, name, and price of the souvenir.
  *
  * @param id Souvenir ID
@@ -72,7 +50,8 @@ void Souvenir::setPrice(double price)
  * @param price Souvenir price
  */
 Souvenir::Souvenir(int id, const std::string& name, double price)
-    : Souvenir(name, price)
+    : m_id(id)
 {
-    m_id = id;
+    setName(name);
+    setPrice(price);
 }

--- a/src/datastore/souvenir.hpp
+++ b/src/datastore/souvenir.hpp
@@ -7,8 +7,8 @@
  * This class holds information about a souvenir. It can be
  * hidden from public use by the @a hidden property.
  *
- * A souvenir with an ID value of -1 means that it hasn't
- * been attached to a stadium.
+ * A souvenir with an ID of -1 means it's invalid and it
+ * isn't attached to a stadium.
  */
 class Souvenir
 {
@@ -17,7 +17,6 @@ public:
 
     /* Constructors */
     Souvenir();
-    Souvenir(const std::string& name, double price);
 
     /* Getters */
     int getId() const;
@@ -33,7 +32,7 @@ public:
 
 private:
     /* Constructors */
-    Souvenir(int id, const std::string&name, double price);
+    Souvenir(int id, const std::string& name, double price);
 
     /* Data */
     int m_id = -1;

--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -132,15 +132,8 @@ void Stadium::setCenterFieldDist(int dist)
  */
 void Stadium::addSouvenir(const std::string& name, double price)
 {
-    /*
-     * Since Souvenir makes Stadium a friend class,
-     * we can directly set the souvenir ID
-     */
-    Souvenir souvenir(name, price);
-    souvenir.m_id = m_nextSouvenirId;
-
+    Souvenir souvenir(m_nextSouvenirId, name, price);
     m_souvenirs[m_nextSouvenirId] = souvenir;
-
     m_nextSouvenirId++;
 }
 

--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -29,9 +29,33 @@ Stadium::Stadium(const std::string& name, const std::string& location)
     setLocation(location);
 }
 
+/**
+ * Constructs a stadium given a name, location, and team. ID and integer
+ * data will be defaulted to -1. Enum data is set to the first item
+ * in the enum.
+ *
+ * If @a name is an empty string, the name is set to "invalid".
+ * If @a location is an empty string, the location is set to "invalid".
+ * If @a team is an invalid team, the team ID of the stadium will be set to -1.
+ *
+ * @param name Stadium name
+ * @param location Stadium location
+ * @param team Team that is home to this stadium
+ */
+Stadium::Stadium(const std::string& name, const std::string& location, const Team& team)
+    : Stadium(name, location)
+{
+    setTeam(team);
+}
+
 int Stadium::getId() const
 {
     return m_id;
+}
+
+int Stadium::getTeamId() const
+{
+    return m_teamId;
 }
 
 std::string Stadium::getName() const
@@ -67,6 +91,16 @@ std::vector<Souvenir> Stadium::getSouvenirs() const
         vec.push_back(souvenir.second);
 
     return vec;
+}
+
+/**
+ * Sets the stadium's team ID reference to the argument's ID.
+ *
+ * @param team Team that resides in the stadium
+ */
+void Stadium::setTeam(const Team& team)
+{
+    m_teamId = team.getId();
 }
 
 /**

--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -12,42 +12,6 @@ const std::array<std::string,6> Stadium::TYPOLOGY_STRING = {"Retro Modern", "Ret
 Stadium::Stadium()
 {}
 
-/**
- * Constructs a stadium given a name and location. ID and integer
- * data will be defaulted to -1. Enum data is set to the first item
- * in the enum.
- *
- * If @a name is an empty string, the name is set to "invalid".
- * If @a location is an empty string, the location is set to "invalid".
- *
- * @param name Stadium name
- * @param location Stadium location
- */
-Stadium::Stadium(const std::string& name, const std::string& location)
-{
-    setName(name);
-    setLocation(location);
-}
-
-/**
- * Constructs a stadium given a name, location, and team. ID and integer
- * data will be defaulted to -1. Enum data is set to the first item
- * in the enum.
- *
- * If @a name is an empty string, the name is set to "invalid".
- * If @a location is an empty string, the location is set to "invalid".
- * If @a team is an invalid team, the team ID of the stadium will be set to -1.
- *
- * @param name Stadium name
- * @param location Stadium location
- * @param team Team that is home to this stadium
- */
-Stadium::Stadium(const std::string& name, const std::string& location, const Team& team)
-    : Stadium(name, location)
-{
-    setTeam(team);
-}
-
 int Stadium::getId() const
 {
     return m_id;
@@ -199,7 +163,8 @@ Souvenir& Stadium::findSouvenir(int id)
  * it to be set on a different line and not buried in a
  * constructor's arguments.
  *
- * @param id Stadium id
+ * @param id Stadium ID
+ * @param teamId ID of the team that resides in this stadium
  * @param name Stadium name
  * @param location Stadium location
  * @param seatCap Stadium's seat capacity
@@ -209,16 +174,15 @@ Souvenir& Stadium::findSouvenir(int id)
  * @param s Stadium's playing surface
  * @param t Stadium's typology
  */
-Stadium::Stadium(int id, const std::string& name, const std::string& location,
+Stadium::Stadium(int id, int teamId,
+                 const std::string& name, const std::string& location,
                  int seatCap, int yearOpened, int centerFieldDist,
                  Roof r, Surface s, Typology t)
-    : Stadium(name, location)
+    : roof(r), surface(s), typology(t), m_id(id), m_teamId(teamId)
 {
-    m_id = id;
-    m_seatCap = seatCap;
-    m_yearOpened = yearOpened;
-    m_centerFieldDist = centerFieldDist;
-    roof = r;
-    surface = s;
-    typology = t;
+    setName(name);
+    setLocation(location);
+    setSeatCap(seatCap);
+    setYearOpened(yearOpened);
+    setCenterFieldDist(centerFieldDist);
 }

--- a/src/datastore/stadium.hpp
+++ b/src/datastore/stadium.hpp
@@ -40,8 +40,6 @@ public:
 
     /* Constructors */
     Stadium();
-    Stadium(const std::string& name, const std::string& location);
-    Stadium(const std::string& name, const std::string& location, const Team&);
 
     /* Getters */
     int getId() const;
@@ -73,7 +71,7 @@ public:
 
 private:
     /* Constructors */
-    Stadium(int id, const std::string& name, const std::string& location,
+    Stadium(int id, int teamId, const std::string& name, const std::string& location,
             int seatCap, int yearOpened, int centerFieldDist,
             Roof, Surface, Typology);
 

--- a/src/datastore/stadium.hpp
+++ b/src/datastore/stadium.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "souvenir.hpp"
+#include "team.hpp"
 #include <map>
 #include <vector>
 #include <array>
@@ -10,13 +11,15 @@
  * This class is used for holding information about a stadium.
  * It can also be hidden from public use through the @a hidden
  * property. A stadium contains a list of souvenirs that it contains.
+ * It also holds a team ID that represents a team who resides in
+ * the stadium.
  *
  * Enum classes are available for information about the stadium's
  * architecture. There is also static variables in the class to
  * convert an enum type to an associated string.
  *
  * Note:
- * All stadiums have their IDs defaulted to -1. The only way for a
+ * All stadium IDs are defaulted to -1. The only way for a
  * stadium to have a valid ID is for it to be created by the
  * @a Database class. This is why @a Database is a friend class.
  */
@@ -38,9 +41,11 @@ public:
     /* Constructors */
     Stadium();
     Stadium(const std::string& name, const std::string& location);
+    Stadium(const std::string& name, const std::string& location, const Team&);
 
     /* Getters */
     int getId() const;
+    int getTeamId() const;
     std::string getName() const;
     std::string getLocation() const;
     int getSeatCap() const;
@@ -49,6 +54,7 @@ public:
     std::vector<Souvenir> getSouvenirs() const;
 
     /* Setters */
+    void setTeam(const Team&);
     void setName(const std::string&);
     void setLocation(const std::string&);
     void setSeatCap(int);
@@ -73,6 +79,7 @@ private:
 
     /* Data */
     int m_id = -1;
+    int m_teamId = -1;
     std::string m_name = "invalid";
     std::string m_location = "invalid";
     int m_seatCap = -1;

--- a/src/datastore/stadium.hpp
+++ b/src/datastore/stadium.hpp
@@ -71,7 +71,8 @@ public:
 
 private:
     /* Constructors */
-    Stadium(int id, int teamId, const std::string& name, const std::string& location,
+    Stadium(int id, int teamId,
+            const std::string& name, const std::string& location,
             int seatCap, int yearOpened, int centerFieldDist,
             Roof, Surface, Typology);
 

--- a/src/datastore/team.cpp
+++ b/src/datastore/team.cpp
@@ -9,47 +9,14 @@ const std::array<std::string,2> Team::LEAGUE_STRING = {"National", "American"};
 Team::Team()
 {}
 
-/**
- * Constructs a team given a name and league. ID data will be
- * defaulted to -1. Enum data is set to the first item in the enum.
- *
- * If @a name is an empty string, the team's name is set to "invalid".
- *
- * The stadium ID is set to -1 to indicate that the team is not
- * in a stadium yet.
- *
- * @param name Team name
- * @param leag Team's league
- */
-Team::Team(const std::string& name, League leag)
-    : league(leag)
-{
-    setName(name);
-}
-
 int Team::getId() const
 {
     return m_id;
 }
 
-int Team::getStadiumId() const
-{
-    return m_stadiumId;
-}
-
 std::string Team::getName() const
 {
     return m_name;
-}
-
-/**
- * Sets the stadium ID given a stadium object.
- *
- * @param stadium Team's stadium
- */
-void Team::setStadium(const Stadium& stadium)
-{
-    m_stadiumId = stadium.getId();
 }
 
 /**
@@ -70,13 +37,11 @@ void Team::setName(const std::string& name)
  * constructor's arguments.
  *
  * @param id Team ID
- * @param stadiumId Team's stadium ID
  * @param name Team name
  * @param leag Team's league
  */
-Team::Team(int id, int stadiumId, const std::string& name, League leag)
-    : Team(name, leag)
+Team::Team(int id, const std::string& name, League leag)
+    : league(leag), m_id(id)
 {
-    m_id = id;
-    m_stadiumId = stadiumId;
+    setName(name);
 }

--- a/src/datastore/team.hpp
+++ b/src/datastore/team.hpp
@@ -1,5 +1,6 @@
 #pragma once
-#include "stadium.hpp"
+#include <string>
+#include <array>
 
 /**
  * @class Team class
@@ -9,11 +10,8 @@
  *
  * A team with an ID of -1 means it's invalid.
  *
- * A team with a stadium ID of -1 means it doesn't reside
- * in a stadium.
- *
  * Note:
- * All teams have their IDs defaulted to -1. The only way for a
+ * All stadium IDs are defaulted to -1. The only way for a
  * team to have a valid ID is for it to be created by the
  * @a Database class. This is why @a Database is a friend class.
  */
@@ -30,27 +28,23 @@ public:
 
     /* Constructors */
     Team();
-    Team(const std::string& name, League);
 
     /* Getters */
     int getId() const;
-    int getStadiumId() const;
     std::string getName() const;
 
     /* Setters */
-    void setStadium(const Stadium&);
     void setName(const std::string&);
 
     /* Public data */
     bool hidden = true;
-    League league;
+    League league = NATIONAL;
 
 private:
     /* Constructors */
-    Team(int id, int stadiumId, const std::string& name, League);
+    Team(int id, const std::string& name, League);
 
     /* Data */
     int m_id = -1;
-    int m_stadiumId = -1;
     std::string m_name = "invalid";
 };

--- a/src/datastore/team.hpp
+++ b/src/datastore/team.hpp
@@ -11,7 +11,7 @@
  * A team with an ID of -1 means it's invalid.
  *
  * Note:
- * All stadium IDs are defaulted to -1. The only way for a
+ * All team IDs are defaulted to -1. The only way for a
  * team to have a valid ID is for it to be created by the
  * @a Database class. This is why @a Database is a friend class.
  */


### PR DESCRIPTION
### Key features
* Removed stadium ID reference from team
* Add team ID reference to stadium. This will only allow a single team to be in a stadium at a single time.
* Remove public ctors from stadium, team, and souvenirs since it should never be used outside of `Database`
* `Database` conforms to these ID changes

### Future Improvements
* none

### Notes
none