### PR TITLE
Returning a nstd::map by value instead of const value

### DIFF
--- a/src/datastore/database.cpp
+++ b/src/datastore/database.cpp
@@ -77,9 +77,9 @@ void Database::loadFromFile(const std::string& filepath)
 /**
  * This method returns all the teams
  *
- * @return teams is returned
+ * @return teams is returned by value
  */
-const nstd::map<int,Team> Database::getTeams()
+nstd::map<int,Team> Database::getTeams()
 {
     return teams;
 }
@@ -87,9 +87,9 @@ const nstd::map<int,Team> Database::getTeams()
 /**
  * This method returns all the Stadiums
  *
- * @return stadiums is returned
+ * @return stadiums is returned by value
  */
-const nstd::map<int,Stadium> Database::getStadiums()
+nstd::map<int,Stadium> Database::getStadiums()
 {
     return stadiums;
 }

--- a/src/datastore/database.hpp
+++ b/src/datastore/database.hpp
@@ -23,8 +23,8 @@ public:
     static void saveToFile(const std::string&);
 
     /* Getters */
-    const static nstd::map<int,Team> getTeams();
-    const static nstd::map<int,Stadium> getStadiums();
+    static nstd::map<int,Team> getTeams();
+    static nstd::map<int,Stadium> getStadiums();
     static Team& findTeamById(int);
     static Stadium& findStadiumById(int);
     static std::vector<std::pair<Team,Stadium>> getTeamsAndStadiums();


### PR DESCRIPTION
Closes #(issue)

### Key features
* return a nstd::map by value instead of const value 

### Future Improvements
* N / A

### Notes
* nstd::map wasn't made to work with const / const ref 