### PR TITLE
Stadium souvenir function additions

### DIFF
--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -128,10 +128,11 @@ void Stadium::setCenterFieldDist(int dist)
  *
  * @param name Souvenir name to add
  * @param price Souvenir price to add
+ * @return ID of the new souvenir
  */
-void Stadium::addSouvenir(const std::string& name, double price)
+int Stadium::addSouvenir(const std::string& name, double price)
 {
-    addSouvenir(name, price, true);
+    return addSouvenir(name, price, true);
 }
 
 /**
@@ -145,13 +146,14 @@ void Stadium::addSouvenir(const std::string& name, double price)
  * @param name Souvenir name to add
  * @param price Souvenir price to add
  * @param hidden Souvenir's hidden state
+ * @param ID of the new souvenir
  */
-void Stadium::addSouvenir(const std::string& name, double price, bool hidden)
+int Stadium::addSouvenir(const std::string& name, double price, bool hidden)
 {
     Souvenir souvenir(m_nextSouvenirId, name, price);
     souvenir.hidden = hidden;
     m_souvenirs[m_nextSouvenirId] = souvenir;
-    m_nextSouvenirId++;
+    return m_nextSouvenirId++;
 }
 
 /**

--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -123,16 +123,33 @@ void Stadium::setCenterFieldDist(int dist)
 /**
  * @brief Add a new souvenir
  *
- * Creates a new souvenir with the given name and price. The
- * souvenir's ID is set by keeping track of how many the
- * stadium currently has. It is then added to map.
+ * Overloaded version of @a addSouvenir(const std::string&, double, bool)
+ * that calls it with @a true as the @a bool.
  *
  * @param name Souvenir name to add
  * @param price Souvenir price to add
  */
 void Stadium::addSouvenir(const std::string& name, double price)
 {
+    addSouvenir(name, price, true);
+}
+
+/**
+ * @brief Add a new souvenir with hidden state
+ *
+ * Creates a new souvenir with the given name, price, and
+ * hidden state. The souvenir's ID is set by keeping of
+ * how many souvenirs the stadium currently has. It is then
+ * added to the stadium's souvenir map.
+ *
+ * @param name Souvenir name to add
+ * @param price Souvenir price to add
+ * @param hidden Souvenir's hidden state
+ */
+void Stadium::addSouvenir(const std::string& name, double price, bool hidden)
+{
     Souvenir souvenir(m_nextSouvenirId, name, price);
+    souvenir.hidden = hidden;
     m_souvenirs[m_nextSouvenirId] = souvenir;
     m_nextSouvenirId++;
 }
@@ -147,6 +164,34 @@ void Stadium::addSouvenir(const std::string& name, double price)
 Souvenir& Stadium::findSouvenir(int id)
 {
     return m_souvenirs[id];
+}
+
+/**
+ * Finds a souvenir given a souvenir ID. Since @a std::map::operator[]
+ * doesn't return a const-reference, we must use @a std::map::at instead.
+ * We wrap the call in a try-catch since @a std::map::at throws an
+ * exception if the item wasn't found. If the item was found, we return it.
+ * If the item wasn't found, we return a static default item.
+ *
+ * @param id ID of souvenir to find
+ * @return If found, returns the souvenir.
+ *         If not found, returns an invalid souvenir.
+ *         Returns a const-reference of the souvenir.
+ */
+const Souvenir& Stadium::findSouvenir(int id) const
+{
+    /* Default souvenir to return if exception caught */
+    static Souvenir error;
+    error = Souvenir();
+
+    try
+    {
+        return m_souvenirs.at(id);
+    }
+    catch(const std::out_of_range&)
+    {
+        return error;
+    }
 }
 
 /**

--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -172,7 +172,7 @@ Souvenir& Stadium::findSouvenir(int id)
     error = Souvenir();
 
     auto it = m_souvenirs.find(id);
-    return it == m_souvenirs.end() ? it->second
+    return it != m_souvenirs.end() ? it->second
                                    : error;
 }
 
@@ -192,7 +192,7 @@ const Souvenir& Stadium::findSouvenir(int id) const
     error = Souvenir();
 
     auto it = m_souvenirs.find(id);
-    return it == m_souvenirs.end() ? it->second
+    return it != m_souvenirs.end() ? it->second
                                    : error;
 }
 

--- a/src/datastore/stadium.cpp
+++ b/src/datastore/stadium.cpp
@@ -157,23 +157,28 @@ int Stadium::addSouvenir(const std::string& name, double price, bool hidden)
 }
 
 /**
- * Finds a souvenir given a souvenir ID.
+ * Finds and returns a reference to a souvenir with the
+ * ID of @a id.
  *
  * @param id ID of souvenir to find
  * @return If found, returns the souvenir.
  *         If not found, returns an invalid souvenir.
+ *         Returns a reference of the souvenir.
  */
 Souvenir& Stadium::findSouvenir(int id)
 {
-    return m_souvenirs[id];
+    /* Default souvenir to return if exception caught */
+    static Souvenir error;
+    error = Souvenir();
+
+    auto it = m_souvenirs.find(id);
+    return it == m_souvenirs.end() ? it->second
+                                   : error;
 }
 
 /**
- * Finds a souvenir given a souvenir ID. Since @a std::map::operator[]
- * doesn't return a const-reference, we must use @a std::map::at instead.
- * We wrap the call in a try-catch since @a std::map::at throws an
- * exception if the item wasn't found. If the item was found, we return it.
- * If the item wasn't found, we return a static default item.
+ * Finds and returns a const-reference to a souvenir with the
+ * ID of @a id.
  *
  * @param id ID of souvenir to find
  * @return If found, returns the souvenir.
@@ -186,14 +191,9 @@ const Souvenir& Stadium::findSouvenir(int id) const
     static Souvenir error;
     error = Souvenir();
 
-    try
-    {
-        return m_souvenirs.at(id);
-    }
-    catch(const std::out_of_range&)
-    {
-        return error;
-    }
+    auto it = m_souvenirs.find(id);
+    return it == m_souvenirs.end() ? it->second
+                                   : error;
 }
 
 /**

--- a/src/datastore/stadium.hpp
+++ b/src/datastore/stadium.hpp
@@ -60,8 +60,8 @@ public:
     void setCenterFieldDist(int);
 
     /* Souvenirs */
-    void addSouvenir(const std::string& name, double price);
-    void addSouvenir(const std::string& name, double price, bool hidden);
+    int addSouvenir(const std::string& name, double price);
+    int addSouvenir(const std::string& name, double price, bool hidden);
     Souvenir& findSouvenir(int id);
     const Souvenir& findSouvenir(int id) const;
 

--- a/src/datastore/stadium.hpp
+++ b/src/datastore/stadium.hpp
@@ -61,7 +61,9 @@ public:
 
     /* Souvenirs */
     void addSouvenir(const std::string& name, double price);
+    void addSouvenir(const std::string& name, double price, bool hidden);
     Souvenir& findSouvenir(int id);
+    const Souvenir& findSouvenir(int id) const;
 
     /* Public data */
     bool hidden = true;


### PR DESCRIPTION
### Key features
* Function that allows to set the hidden state of a new souvenir `addSouvenir(const std::string&, double, bool)`
* `addSouvenir` now returns the ID of the new souvenir
* Function that allows a const version of `findSouvenir`
* Edited `findSouvenir` to use `std::map::find` instead of `std::map::operator[]` to allow for out-of-bounds checking

### Future Improvements
* none

### Notes
none