### PR TITLE
Admin view

### DIFF
--- a/GrayonSlam.pro
+++ b/GrayonSlam.pro
@@ -39,7 +39,8 @@ SOURCES += \
     src/datastore/database.cpp \
     src/views/stadiumview.cpp \
     src/widgets/stadiumlist.cpp \
-    src/widgets/stadiumlistitem.cpp
+    src/widgets/stadiumlistitem.cpp \
+    src/views/adminview.cpp
 
 HEADERS += \
     src/windows/mainwindow.hpp \
@@ -59,14 +60,16 @@ HEADERS += \
     src/utils/enumtools.hpp \
     src/views/stadiumview.hpp \
     src/widgets/stadiumlist.hpp \
-    src/widgets/stadiumlistitem.hpp
+    src/widgets/stadiumlistitem.hpp \
+    src/views/adminview.hpp
 
 FORMS += \
     src/windows/mainwindow.ui \
     src/windows/login.ui \
     src/widgets/navbaritem.ui \
     src/widgets/souvenirlistitem.ui \
-    src/views/stadiumview.ui
+    src/views/stadiumview.ui \
+    src/views/adminview.ui
 
 RESOURCES += \
     res.qrc

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -80,7 +80,11 @@ void AdminView::loadSouvenirLists(int stadiumId)
 /**
  * @brief Fill stadium edit fields
  *
+ * Fills all the stadium edit fields with information about a stadium
+ * that is represented by @a stadiumId.
  *
+ * If @a stadiumId doesn't represent an existing stadium, this
+ * function does nothing.
  *
  * @param stadiumId Stadium ID to fill the edit fields with
  */
@@ -88,14 +92,27 @@ void AdminView::fillStadiumEditFields(int stadiumId)
 {
     /* Extract stadium from database and check if valid */
     const Stadium& stadium = Database::findStadiumById(stadiumId);
-//    const Team& team = Database::findTeamById(stadiumId.getTeamId());
     if(stadium.getId() == -1)
         return;
 
+    //Extract the team that lives in the stadium
+    const Team& team = Database::findTeamById(stadium.getTeamId());
+
+    /* Fill line edits */
     m_ui->lineEdit_stadName->setText(QString::fromStdString(stadium.getName()));
     m_ui->lineEdit_stadLocation->setText(QString::fromStdString(stadium.getLocation()));
-    m_ui->lineEdit_stadTeamName->setText("wuhoh");
-    m_ui->comboBox_stadLeague->
+    m_ui->lineEdit_stadTeamName->setText(QString::fromStdString(team.getName()));
+
+    /* Fill combo boxes (1 is added since the initial is an empty string) */
+    m_ui->comboBox_stadTeamLeague->setCurrentIndex(team.league + 1);
+    m_ui->comboBox_stadRoof->setCurrentIndex(stadium.roof + 1);
+    m_ui->comboBox_stadSurface->setCurrentIndex(stadium.surface + 1);
+    m_ui->comboBox_stadTypology->setCurrentIndex(stadium.typology + 1);
+
+    /* Fill spin boxes */
+    m_ui->spinBox_stadYearOpened->setValue(stadium.getYearOpened());
+    m_ui->spinBox_stadSeatCap->setValue(stadium.getSeatCap());
+    m_ui->spinBox_stadCenterDist->setValue(stadium.getCenterFieldDist());
 }
 
 /**

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -1,0 +1,13 @@
+#include "adminview.hpp"
+#include "ui_adminview.h"
+
+AdminView::AdminView(QWidget* parent)
+    : View(parent), m_ui(new Ui::AdminView)
+{
+    m_ui->setupUi(this);
+}
+
+AdminView::~AdminView()
+{
+    delete m_ui;
+}

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -1,13 +1,107 @@
 #include "adminview.hpp"
 #include "ui_adminview.h"
+#include "src/datastore/database.hpp"
 
 AdminView::AdminView(QWidget* parent)
     : View(parent), m_ui(new Ui::AdminView)
 {
     m_ui->setupUi(this);
+
+    /* Initialize souvenir lists */
+    m_availableSouvenirList = new SouvenirList(m_ui->widget_souvAvailableList);
+    m_hiddenSouvenirList = new SouvenirList(m_ui->widget_souvHiddenList);
+    m_hiddenSouvenirList->allowHidden(true);
 }
 
+/**
+ * Deletes all the widgets in the view.
+ */
 AdminView::~AdminView()
 {
     delete m_ui;
+    delete m_availableSouvenirList;
+    delete m_hiddenSouvenirList;
+}
+
+/**
+ * Resets the stacked widget page and UI by calling @a resetUi().
+ */
+void AdminView::resetView()
+{
+    //Change to stadium list page
+    m_ui->stackedWidget->setCurrentIndex(0);
+
+    m_currentStadiumId = -1;
+
+    resetUi();
+}
+
+/**
+ * Resets the UI to their original state.
+ */
+void AdminView::resetUi()
+{
+    loadSouvenirLists(m_currentStadiumId);
+}
+
+/**
+ * @brief Clear and load souvenir lists
+ *
+ * A stadium object is extracted from the database using @a stadiumId.
+ * The souvenirs of the extracted stadium is used to fill the
+ * available and hidden souvenir lists. As a precaution, the lists
+ * are cleared to remove any leftover items in the lists.
+ *
+ * If the passed ID results in an invalid stadium, this function does nothing.
+ *
+ * @param stadiumId Stadium ID with souvenirs to use in the lists
+ */
+void AdminView::loadSouvenirLists(int stadiumId)
+{
+    /* Extract stadium from database and check if valid */
+    const Stadium& stadium = Database::findStadiumById(stadiumId);
+    if(stadium.getId() == -1)
+        return;
+
+    /* Clear current lists */
+    m_availableSouvenirList->clear();
+    m_hiddenSouvenirList->clear();
+
+    /* Get the stadium and add each souvenir into the lists */
+    for(const Souvenir& souvenir : stadium.getSouvenirs())
+    {
+        if(souvenir.hidden)
+            m_hiddenSouvenirList->addItem(stadium.getId(), souvenir);
+        else
+            m_availableSouvenirList->addItem(stadium.getId(), souvenir);
+    }
+}
+
+/**
+ * @brief Fill stadium edit fields
+ *
+ *
+ *
+ * @param stadiumId Stadium ID to fill the edit fields with
+ */
+void AdminView::fillStadiumEditFields(int stadiumId)
+{
+    /* Extract stadium from database and check if valid */
+    const Stadium& stadium = Database::findStadiumById(stadiumId);
+//    const Team& team = Database::findTeamById(stadiumId.getTeamId());
+    if(stadium.getId() == -1)
+        return;
+
+    m_ui->lineEdit_stadName->setText(QString::fromStdString(stadium.getName()));
+    m_ui->lineEdit_stadLocation->setText(QString::fromStdString(stadium.getLocation()));
+    m_ui->lineEdit_stadTeamName->setText("wuhoh");
+    m_ui->comboBox_stadLeague->
+}
+
+/**
+ * Goes back to stadium list page by calling @a resetView().
+ */
+void AdminView::on_pushButton_souvGoBack_clicked()
+{
+    resetView();
 }

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -79,6 +79,8 @@ void AdminView::resetView()
  */
 void AdminView::resetUi()
 {
+    Database::saveToFile("MLBInformation.csv");
+
     fillStadiumList();
     fillSouvenirLists(m_currentStadiumId);
 

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -2,6 +2,7 @@
 #include "ui_adminview.h"
 #include "src/datastore/database.hpp"
 #include <QFileDialog>
+#include <QTimer>
 
 AdminView::AdminView(QWidget* parent)
     : View(parent), m_ui(new Ui::AdminView)
@@ -218,7 +219,10 @@ void AdminView::on_pushButton_stadConfirmEdit_clicked()
     /* Extract stadium from database and check if valid */
     Stadium& stadium = Database::findStadiumById(m_currentStadiumId);
     if(stadium.getId() == -1)
+    {
+        markButtonAsError(m_ui->pushButton_stadConfirmEdit);
         return;
+    }
 
     //Extract team from database
     Team& team = Database::findTeamById(stadium.getTeamId());
@@ -250,7 +254,10 @@ void AdminView::on_pushButton_stadConfirmEdit_clicked()
     if(stadName.isEmpty() || loc.isEmpty()   || teamName.isEmpty() ||
        leagueIndex == -1  || roofIndex == -1 ||
        surfaceIndex == -1 || typologyIndex == -1)
+    {
+        markButtonAsError(m_ui->pushButton_stadConfirmEdit);
         return;
+    }
 
     /* Enum conversions */
     Team::League league = static_cast<Team::League>(leagueIndex);
@@ -292,12 +299,19 @@ void AdminView::on_pushButton_stadAddFromFile_clicked()
     /* Prompt for stadium info file and check if request was cancelled */
     QString stadFile = QFileDialog::getOpenFileName(this, "Add stadiums", QDir::homePath(), "Stadium information file (*.csv)");
     if(stadFile.isEmpty())
+    {
+        markButtonAsError(m_ui->pushButton_stadAddFromFile);
         return;
+    }
 
     /* Prompt for stadium distances info file and check if request was cancelled */
     QString distFile = QFileDialog::getOpenFileName(this, "Add distances", QDir::homePath(), "Distances information file (*.csv)");
     if(distFile.isEmpty())
+    {
+        markButtonAsError(m_ui->pushButton_stadAddFromFile);
         return;
+    }
+
 
     /* Use the files to load data into the database */
     Database::loadFromFile(stadFile.toStdString());
@@ -319,7 +333,11 @@ void AdminView::on_pushButton_stadEditSouvenirs_clicked()
     /* Extract stadium from database and check if valid */
     const Stadium& stadium = Database::findStadiumById(m_currentStadiumId);
     if(stadium.getId() == -1)
+    {
+        markButtonAsError(m_ui->pushButton_stadEditSouvenirs);
         return;
+    }
+
 
     resetUi();
 
@@ -372,7 +390,10 @@ void AdminView::on_pushButton_souvConfirmEdit_clicked()
     /* Error check currently selected souvenir and input */
     SouvenirId id = getCurrentSouvenirId();
     if(id == -1 || name.isEmpty() || price == 0.0)
+    {
+        markButtonAsError(m_ui->pushButton_souvConfirmEdit);
         return;
+    }
 
     /* Extract stadium and souvenir from database */
     Stadium& stadium = Database::findStadiumById(m_currentStadiumId);
@@ -404,7 +425,10 @@ void AdminView::on_pushButton_souvConfirmAdd_clicked()
 
     /* Error check input */
     if(name.isEmpty() || price == 0.0)
+    {
+        markButtonAsError(m_ui->pushButton_souvConfirmAdd);
         return;
+    }
 
     /* Extract stadium and souvenir from database */
     Stadium& stadium = Database::findStadiumById(m_currentStadiumId);
@@ -419,4 +443,20 @@ void AdminView::on_pushButton_souvConfirmAdd_clicked()
 void AdminView::on_pushButton_souvReturn_clicked()
 {
     resetView();
+}
+
+/**
+ * @brief Mark a button with an error
+ *
+ * Takes a button and changes the text color to red to signify
+ * and error has happened. After 2000 milliseconds, the stylesheet
+ * is returned to its original setting.
+ *
+ * @param button Button to mark with error
+ */
+void AdminView::markButtonAsError(QPushButton* button)
+{
+    QString style = button->styleSheet();
+    button->setStyleSheet("QPushButton { color: red; }");
+    QTimer::singleShot(2000, [=]{ button->setStyleSheet(style); });
 }

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -8,6 +8,9 @@ AdminView::AdminView(QWidget* parent)
 {
     m_ui->setupUi(this);
 
+    /* Initialize stadium list */
+    m_stadiumList = new StadiumList(m_ui->widget_stadList);
+
     /* Initialize souvenir lists */
     m_availableSouvenirList = new SouvenirList(m_ui->widget_souvAvailableList);
     m_hiddenSouvenirList = new SouvenirList(m_ui->widget_souvHiddenList);
@@ -18,7 +21,7 @@ AdminView::AdminView(QWidget* parent)
      * new stadium ID that is emitted by the stadium list and
      * the stadium edit fields are filled
      */
-    connect(m_ui->spinBox, qOverload<int>(&QSpinBox::valueChanged), //TODO replace spinbox with stadium list
+    connect(m_stadiumList, &StadiumList::stadiumClicked,
             [&](int id)
             {
                 m_currentStadiumId = id;
@@ -110,7 +113,7 @@ void AdminView::resetUi()
  */
 void AdminView::fillStadiumList()
 {
-    //TODO waiting for stadium list
+    m_stadiumList->populateWidget(Database::getTeamsAndStadiums());
 }
 
 /**

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -139,10 +139,8 @@ void AdminView::fillSouvenirLists(StadiumId stadiumId)
     /* Get the stadium and add each souvenir into the lists */
     for(const Souvenir& souvenir : stadium.getSouvenirs())
     {
-        if(souvenir.hidden)
-            m_hiddenSouvenirList->addItem(stadium.getId(), souvenir);
-        else
-            m_availableSouvenirList->addItem(stadium.getId(), souvenir);
+        (souvenir.hidden ? m_hiddenSouvenirList
+                         : m_availableSouvenirList)->addItem(stadium.getId(), souvenir);
     }
 }
 

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -55,6 +55,7 @@ AdminView::AdminView(QWidget* parent)
 AdminView::~AdminView()
 {
     delete m_ui;
+    delete m_stadiumList;
     delete m_availableSouvenirList;
     delete m_hiddenSouvenirList;
 }

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -110,16 +110,7 @@ void AdminView::resetUi()
  */
 void AdminView::fillStadiumList()
 {
-    /*
-     * BUG
-     * If this line exists, the souvenir lists won't load because
-     * fillStadiumList() is called before fillSouvenirLists()
-     * and it requires m_currentStadiumId.
-     * Hopefully, when StadiumList arrives, we don't need to
-     * have this line at all.
-     */
-//    m_currentStadiumId = -1;
-    m_ui->spinBox->setValue(m_currentStadiumId);
+    //TODO waiting for stadium list
 }
 
 /**

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -278,6 +278,35 @@ void AdminView::on_pushButton_souvConfirmEdit_clicked()
 }
 
 /**
+ * @brief Add new souvenir to the stadium
+ *
+ * Obtain input from UI and add a new souvenir to the stadium.
+ * Resets the UI to reload the souvenir lists.
+ *
+ * If the input is invalid (empty strings, invalid ID, or $0.0 for price),
+ * then this function does nothing.
+ */
+void AdminView::on_pushButton_souvConfirmAdd_clicked()
+{
+    /* Extract input from UI */
+    const QString& name = m_ui->lineEdit_souvAddName->text();
+    double price = m_ui->doubleSpinBox_souvAddPrice->value();
+    bool hidden = m_ui->checkBox_souvAddHidden->checkState() == Qt::CheckState::Checked;
+
+    /* Error check currently selected souvenir and input */
+    SouvenirId id = getCurrentSouvenirId();
+    if(id == -1 || name.isEmpty() || price == 0.0)
+        return;
+
+    /* Extract stadium and souvenir from database */
+    Stadium& stadium = Database::findStadiumById(m_currentStadiumId);
+    stadium.addSouvenir(name.toStdString(), price);
+    //TODO set the hidden state
+
+    resetUi();
+}
+
+/**
  * Goes back to stadium list page by calling @a resetView().
  */
 void AdminView::on_pushButton_souvReturn_clicked()

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -11,6 +11,8 @@ AdminView::AdminView(QWidget* parent)
     m_availableSouvenirList = new SouvenirList(m_ui->widget_souvAvailableList);
     m_hiddenSouvenirList = new SouvenirList(m_ui->widget_souvHiddenList);
     m_hiddenSouvenirList->allowHidden(true);
+
+    connect(m_ui->spinBox, qOverload<int>(&QSpinBox::valueChanged), this, &AdminView::fillStadiumEditFields);
 }
 
 /**
@@ -114,6 +116,20 @@ void AdminView::fillStadiumEditFields(int stadiumId)
     m_ui->spinBox_stadSeatCap->setValue(stadium.getSeatCap());
     m_ui->spinBox_stadCenterDist->setValue(stadium.getCenterFieldDist());
 }
+
+void AdminView::on_pushButton_stadEditSouvenirs_clicked()
+{
+    m_currentStadiumId = m_ui->spinBox->value(); //TODO replace with selected ID from stadium list
+
+    /* Extract stadium from database and check if valid */
+    const Stadium& stadium = Database::findStadiumById(m_currentStadiumId);
+    if(stadium.getId() == -1)
+        return;
+
+    resetUi();
+    m_ui->stackedWidget->setCurrentIndex(1);
+}
+
 
 /**
  * Goes back to stadium list page by calling @a resetView().

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -243,9 +243,9 @@ void AdminView::on_pushButton_stadConfirmEdit_clicked()
     int typologyIndex = m_ui->comboBox_stadTypology->currentIndex() - 1;
 
     /* Error check input */
-    if(stadName.isEmpty() || loc.isEmpty() || teamName.isEmpty() ||
-       leagueIndex < 0    || roofIndex < 0 ||
-       surfaceIndex < 0   || typologyIndex < 0)
+    if(stadName.isEmpty() || loc.isEmpty()   || teamName.isEmpty() ||
+       leagueIndex == -1  || roofIndex == -1 ||
+       surfaceIndex == -1 || typologyIndex == -1)
         return;
 
     /* Enum conversions */

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -314,7 +314,6 @@ void AdminView::on_pushButton_stadAddFromFile_clicked()
         return;
     }
 
-
     /* Use the files to load data into the database */
     Database::loadFromFile(stadFile.toStdString());
     Database::loadDistancesFromFile(distFile.toStdString());
@@ -339,7 +338,6 @@ void AdminView::on_pushButton_stadEditSouvenirs_clicked()
         markButtonAsError(m_ui->pushButton_stadEditSouvenirs);
         return;
     }
-
 
     resetUi();
 

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -12,25 +12,29 @@ AdminView::AdminView(QWidget* parent)
     m_hiddenSouvenirList = new SouvenirList(m_ui->widget_souvHiddenList);
     m_hiddenSouvenirList->allowHidden(true);
 
+    //TODO replace spinbox with stadium list
     connect(m_ui->spinBox, qOverload<int>(&QSpinBox::valueChanged), this, &AdminView::fillStadiumEditFields);
 
+    /*
+     * These connections will unselect items of the other list.
+     * This will be used for selecting what souvenir will be chosen
+     * when editing.
+     */
     connect(m_availableSouvenirList, &SouvenirList::currentSouvenirChanged,
             [&](IDs ids)
             {
-                //Deselect current selection on hidden souvenir list
                 m_hiddenSouvenirList->setCurrentRow(-1);
-
                 fillSouvenirEditFields(ids.second);
             });
 
     connect(m_hiddenSouvenirList, &SouvenirList::currentSouvenirChanged,
             [&](IDs ids)
             {
-                //Deselect current selection on hidden souvenir list
                 m_availableSouvenirList->setCurrentRow(-1);
-
                 fillSouvenirEditFields(ids.second);
             });
+
+    resetView();
 }
 
 /**
@@ -44,7 +48,7 @@ AdminView::~AdminView()
 }
 
 /**
- * Resets the stacked widget page and UI by calling @a resetUi().
+ * Resets the admin view as if it was just created.
  */
 void AdminView::resetView()
 {
@@ -62,6 +66,26 @@ void AdminView::resetView()
 void AdminView::resetUi()
 {
     loadSouvenirLists(m_currentStadiumId);
+
+    /* Line edits */
+    m_ui->lineEdit_stadName->clear();
+    m_ui->lineEdit_stadLocation->clear();
+    m_ui->lineEdit_stadTeamName->clear();
+    m_ui->lineEdit_souvAddName->clear();
+    m_ui->lineEdit_souvEditName->clear();
+
+    /* Combo boxes */
+    m_ui->comboBox_stadTeamLeague->setCurrentIndex(0);
+    m_ui->comboBox_stadRoof->setCurrentIndex(0);
+    m_ui->comboBox_stadSurface->setCurrentIndex(0);
+    m_ui->comboBox_stadTypology->setCurrentIndex(0);
+
+    /* Spin boxes */
+    m_ui->spinBox_stadYearOpened->clear();
+    m_ui->spinBox_stadSeatCap->clear();
+    m_ui->spinBox_stadCenterDist->clear();
+    m_ui->doubleSpinBox_souvAddPrice->clear();
+    m_ui->doubleSpinBox_souvEditPrice->clear();
 }
 
 /**
@@ -150,7 +174,14 @@ void AdminView::on_pushButton_stadEditSouvenirs_clicked()
 
 /**
  * @brief Fill souvenir edit fields
- * @param souvenirId
+ *
+ * Fills all the souvenir edit fields with information about a
+ * souvenir that is represented by @a souvenirId.
+ *
+ * The stadium used to determine which souvenirs to get is
+ * determined by @a m_currentStadiumId.
+ *
+ * @param souvenirId Souvenir ID of @a m_currentStadiumId to fill the edit fields with
  */
 void AdminView::fillSouvenirEditFields(int souvenirId)
 {
@@ -166,7 +197,9 @@ void AdminView::fillSouvenirEditFields(int souvenirId)
 }
 
 /**
- * @brief Hide or resture currently selected souvenir from the either list
+ * @brief Hide or restore currently selected souvenir from the souvenir lists
+ *
+ * Obtains
  */
 void AdminView::on_pushButton_souvHideRestore_clicked()
 {
@@ -183,6 +216,8 @@ void AdminView::on_pushButton_souvHideRestore_clicked()
 
     //Flip the hidden state
     souvenir.hidden = !souvenir.hidden;
+
+    resetUi();
 }
 
 /**

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -340,7 +340,7 @@ void AdminView::on_pushButton_stadEditSouvenirs_clicked()
 void AdminView::fillSouvenirEditFields(SouvenirId souvenirId)
 {
     /* Extract stadium from database and check if valid */
-    Stadium stadium = Database::findStadiumById(m_currentStadiumId);
+    const Stadium& stadium = Database::findStadiumById(m_currentStadiumId);
     if(stadium.getId() == -1)
         return;
 
@@ -408,8 +408,7 @@ void AdminView::on_pushButton_souvConfirmAdd_clicked()
 
     /* Extract stadium and souvenir from database */
     Stadium& stadium = Database::findStadiumById(m_currentStadiumId);
-    stadium.addSouvenir(name.toStdString(), price);
-    //TODO set the hidden state
+    stadium.addSouvenir(name.toStdString(), price, hidden);
 
     resetUi();
 }

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -1,6 +1,7 @@
 #include "adminview.hpp"
 #include "ui_adminview.h"
 #include "src/datastore/database.hpp"
+#include <QFileDialog>
 
 AdminView::AdminView(QWidget* parent)
     : View(parent), m_ui(new Ui::AdminView)
@@ -274,6 +275,35 @@ void AdminView::on_pushButton_stadConfirmEdit_clicked()
 }
 
 /**
+ * @brief Add stadiums and their distances from a file into the database
+ *
+ * Prompt for a stadium information file that holds information about the
+ * new stadiums. Once that is completed, prompt for a stadium distances
+ * information file that holds information about the distances of the
+ * new stadiums. Tell the database to load these new files into itself.
+ *
+ * The required file extensions is @a .csv.
+ *
+ * If either prompts are cancelled, this function does nothing.
+ */
+void AdminView::on_pushButton_stadAddFromFile_clicked()
+{
+    /* Prompt for stadium info file and check if request was cancelled */
+    QString stadFile = QFileDialog::getOpenFileName(this, "Add stadiums", QDir::homePath(), "Stadium information file (*.csv)");
+    if(stadFile.isEmpty())
+        return;
+
+    /* Prompt for stadium distances info file and check if request was cancelled */
+    QString distFile = QFileDialog::getOpenFileName(this, "Add distances", QDir::homePath(), "Distances information file (*.csv)");
+    if(distFile.isEmpty())
+        return;
+
+    /* Use the files to load data into the database */
+    Database::loadFromFile(stadFile.toStdString());
+    Database::loadDistancesFromFile(distFile.toStdString());
+}
+
+/**
  * @brief Change to souvenir page
  *
  * Obtains the currently selected stadium from the stadium list.
@@ -361,8 +391,8 @@ void AdminView::on_pushButton_souvConfirmEdit_clicked()
  * Obtain input from UI and add a new souvenir to the stadium.
  * Resets the UI to reload the souvenir lists.
  *
- * If the input is invalid (empty strings, invalid ID, or $0.0 for price),
- * then this function does nothing.
+ * If the input is invalid (empty strings, invalid souvenir ID,
+ * or 0 for price), then this function does nothing.
  */
 void AdminView::on_pushButton_souvConfirmAdd_clicked()
 {

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -129,7 +129,7 @@ void AdminView::fillSouvenirLists(int stadiumId)
  * If @a stadiumId doesn't represent an existing stadium, this
  * function does nothing.
  *
- * @param stadiumId Stadium ID to fill the edit fields with
+ * @param stadiumId ID of Stadium to fill the edit fields with
  */
 void AdminView::fillStadiumEditFields(int stadiumId)
 {
@@ -158,6 +158,16 @@ void AdminView::fillStadiumEditFields(int stadiumId)
     m_ui->spinBox_stadCenterDist->setValue(stadium.getCenterFieldDist());
 }
 
+/**
+ * @brief Change to souvenir page
+ *
+ * Obtains the currently selected stadium from the stadium list.
+ * The UI is reset and the stacked widget page is changed to
+ * the souvenir page.
+ *
+ * If the ID of the currently selected stadium is an invalid
+ * ID (-1), this function does nothing besides store the ID.
+ */
 void AdminView::on_pushButton_stadEditSouvenirs_clicked()
 {
     m_currentStadiumId = m_ui->spinBox->value(); //TODO replace with selected ID from stadium list
@@ -168,6 +178,8 @@ void AdminView::on_pushButton_stadEditSouvenirs_clicked()
         return;
 
     resetUi();
+
+    //Change to souvenir page
     m_ui->stackedWidget->setCurrentIndex(1);
 }
 
@@ -180,7 +192,7 @@ void AdminView::on_pushButton_stadEditSouvenirs_clicked()
  * The stadium used to determine which souvenirs to get is
  * determined by @a m_currentStadiumId.
  *
- * @param souvenirId Souvenir ID of @a m_currentStadiumId to fill the edit fields with
+ * @param souvenirId ID of Souvenir of @a m_currentStadiumId to fill the edit fields with
  */
 void AdminView::fillSouvenirEditFields(int souvenirId)
 {
@@ -196,9 +208,16 @@ void AdminView::fillSouvenirEditFields(int souvenirId)
 }
 
 /**
- * @brief Hide or restore currently selected souvenir from the souvenir lists
+ * @brief Hide or restore currently selected souvenir
  *
- * Obtains
+ * Obtain a valid ID from either souvenir list (available and hidden).
+ * Extract the souvenir using the current stadium ID @a m_currentStadiumId
+ * and the obtained valid souvenir ID from the lists. The souvenir's
+ * hidden state is flipped. Finally, the UI is reset so the souvenir
+ * lists reload.
+ *
+ * If neither list returns a currently selected souvenir
+ * ID, then this function does nothing.
  */
 void AdminView::on_pushButton_souvHideRestore_clicked()
 {

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -110,7 +110,15 @@ void AdminView::resetUi()
  */
 void AdminView::fillStadiumList()
 {
-    m_currentStadiumId = -1;
+    /*
+     * BUG
+     * If this line exists, the souvenir lists won't load because
+     * fillStadiumList() is called before fillSouvenirLists()
+     * and it requires m_currentStadiumId.
+     * Hopefully, when StadiumList arrives, we don't need to
+     * have this line at all.
+     */
+//    m_currentStadiumId = -1;
     m_ui->spinBox->setValue(m_currentStadiumId);
 }
 
@@ -401,9 +409,8 @@ void AdminView::on_pushButton_souvConfirmAdd_clicked()
     double price = m_ui->doubleSpinBox_souvAddPrice->value();
     bool hidden = m_ui->checkBox_souvAddHidden->checkState() == Qt::CheckState::Checked;
 
-    /* Error check currently selected souvenir and input */
-    SouvenirId id = getCurrentSouvenirId();
-    if(id == -1 || name.isEmpty() || price == 0.0)
+    /* Error check input */
+    if(name.isEmpty() || price == 0.0)
         return;
 
     /* Extract stadium and souvenir from database */

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -64,6 +64,7 @@ void AdminView::resetView()
  */
 void AdminView::resetUi()
 {
+    fillStadiumList();
     fillSouvenirLists(m_currentStadiumId);
 
     /* Line edits */
@@ -85,6 +86,17 @@ void AdminView::resetUi()
     m_ui->spinBox_stadCenterDist->clear();
     m_ui->doubleSpinBox_souvAddPrice->clear();
     m_ui->doubleSpinBox_souvEditPrice->clear();
+}
+
+/**
+ * @brief Clear and load stadium list
+ *
+ * Obtains all the team and stadium information from the database.
+ * All non-hidden stadiums are loaded into the stadium list.
+ */
+void AdminView::fillStadiumList()
+{
+    //TODO waiting for stadium list
 }
 
 /**
@@ -170,7 +182,8 @@ void AdminView::fillStadiumEditFields(int stadiumId)
  */
 void AdminView::on_pushButton_stadEditSouvenirs_clicked()
 {
-    m_currentStadiumId = m_ui->spinBox->value(); //TODO replace with selected ID from stadium list
+    //TODO replace with selected ID from stadium list
+    m_currentStadiumId = m_ui->spinBox->value();
 
     /* Extract stadium from database and check if valid */
     const Stadium& stadium = Database::findStadiumById(m_currentStadiumId);

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -208,8 +208,8 @@ SouvenirId AdminView::getCurrentSouvenirId() const
  * Obtain input from UI and edit the currently selected stadium
  * with the input. Resets the UI to reload the stadium list.
  *
- * If the input is invalid (empty strings, invalid ID, or $0.0 for price),
- * then this function does nothing.
+ * If the input is invalid (empty strings, invalid stadium ID,
+ * or invalid enum indices), then this function does nothing.
  */
 void AdminView::on_pushButton_stadConfirmEdit_clicked()
 {
@@ -328,8 +328,8 @@ void AdminView::fillSouvenirEditFields(SouvenirId souvenirId)
  * Obtain input from UI and edit the currently selected souvenir
  * with the input. Resets the UI to reload the souvenir lists.
  *
- * If the input is invalid (empty strings, invalid ID, or $0.0 for price),
- * then this function does nothing.
+ * If the input is invalid (empty strings, invalid souvenir ID,
+ * or 0 for price), then this function does nothing.
  */
 void AdminView::on_pushButton_souvConfirmEdit_clicked()
 {

--- a/src/views/adminview.cpp
+++ b/src/views/adminview.cpp
@@ -16,9 +16,8 @@ AdminView::AdminView(QWidget* parent)
     connect(m_ui->spinBox, qOverload<int>(&QSpinBox::valueChanged), this, &AdminView::fillStadiumEditFields);
 
     /*
-     * These connections will unselect items of the other list.
-     * This will be used for selecting what souvenir will be chosen
-     * when editing.
+     * These connections will unselect items of the other list and
+     * fill the souvenir edit fields with the selected item.
      */
     connect(m_availableSouvenirList, &SouvenirList::currentSouvenirChanged,
             [&](IDs ids)
@@ -65,7 +64,7 @@ void AdminView::resetView()
  */
 void AdminView::resetUi()
 {
-    loadSouvenirLists(m_currentStadiumId);
+    fillSouvenirLists(m_currentStadiumId);
 
     /* Line edits */
     m_ui->lineEdit_stadName->clear();
@@ -94,13 +93,13 @@ void AdminView::resetUi()
  * A stadium object is extracted from the database using @a stadiumId.
  * The souvenirs of the extracted stadium is used to fill the
  * available and hidden souvenir lists. As a precaution, the lists
- * are cleared to remove any leftover items in the lists.
+ * are cleared to remove any leftover items in the lists before fill.
  *
  * If the passed ID results in an invalid stadium, this function does nothing.
  *
  * @param stadiumId Stadium ID with souvenirs to use in the lists
  */
-void AdminView::loadSouvenirLists(int stadiumId)
+void AdminView::fillSouvenirLists(int stadiumId)
 {
     /* Extract stadium from database and check if valid */
     const Stadium& stadium = Database::findStadiumById(stadiumId);

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -29,7 +29,7 @@ private slots:
     void fillStadiumEditFields(int stadiumId);
 
     /* Souvenir subview controls */
-    void fillSouvenirEditFields(int souvenirId);
+//    void fillSouvenirEditFields(int souvenirId);
     void on_pushButton_souvGoBack_clicked();
 
 private:

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -34,6 +34,7 @@ private slots:
     /* Souvenir subview controls */
     void fillSouvenirEditFields(SouvenirId);
     void on_pushButton_souvConfirmEdit_clicked();
+    void on_pushButton_souvConfirmAdd_clicked();
     void on_pushButton_souvReturn_clicked();
 
 private:

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -27,6 +27,7 @@ private slots:
 
     /* Stadium subview controls */
     void fillStadiumEditFields(int stadiumId);
+    void on_pushButton_stadEditSouvenirs_clicked();
 
     /* Souvenir subview controls */
 //    void fillSouvenirEditFields(int souvenirId);

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "view.hpp"
+#include "src/widgets/souvenirlist.hpp"
 
 namespace Ui
 {
@@ -11,12 +12,31 @@ class AdminView : public View
     Q_OBJECT
 
 public:
+    /* Constructors */
     explicit AdminView(QWidget* parent);
+
+    /* Destructor */
     ~AdminView() override;
 
-    void resetView() override {}
-    void resetUi() override {}
+    /* Resets */
+    void resetView() override;
+    void resetUi() override;
+
+private slots:
+    void loadSouvenirLists(int stadiumId);
+
+    /* Stadium subview controls */
+    void fillStadiumEditFields(int stadiumId);
+
+    /* Souvenir subview controls */
+    void fillSouvenirEditFields(int souvenirId);
+    void on_pushButton_souvGoBack_clicked();
 
 private:
     Ui::AdminView* m_ui;
+    int m_currentStadiumId = -1;
+
+    /* Widgets */
+    SouvenirList* m_availableSouvenirList;
+    SouvenirList* m_hiddenSouvenirList;
 };

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -23,7 +23,7 @@ public:
     void resetUi() override;
 
 private slots:
-    void loadSouvenirLists(int stadiumId);
+    void fillSouvenirLists(int stadiumId);
 
     /* Stadium subview controls */
     void fillStadiumEditFields(int stadiumId);

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include "view.hpp"
+
+namespace Ui
+{
+class AdminView;
+}
+
+class AdminView : public View
+{
+    Q_OBJECT
+
+public:
+    explicit AdminView(QWidget* parent);
+    ~AdminView() override;
+
+    void resetView() override {}
+    void resetUi() override {}
+
+private:
+    Ui::AdminView* m_ui;
+};

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -2,6 +2,7 @@
 #include "view.hpp"
 #include "src/widgets/souvenirlist.hpp"
 #include "src/widgets/stadiumlist.hpp"
+#include <QPushButton>
 
 namespace Ui
 {
@@ -39,6 +40,9 @@ private slots:
     void on_pushButton_souvConfirmEdit_clicked();
     void on_pushButton_souvConfirmAdd_clicked();
     void on_pushButton_souvReturn_clicked();
+
+    /* Helpers */
+    void markButtonAsError(QPushButton*);
 
 private:
     Ui::AdminView* m_ui;

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -29,6 +29,7 @@ private slots:
 
     /* Stadium subview controls */
     void fillStadiumEditFields(StadiumId);
+    void on_pushButton_stadConfirmEdit_clicked();
     void on_pushButton_stadEditSouvenirs_clicked();
 
     /* Souvenir subview controls */

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -23,6 +23,7 @@ public:
     void resetUi() override;
 
 private slots:
+    void fillStadiumList();
     void fillSouvenirLists(int stadiumId);
 
     /* Stadium subview controls */

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -30,6 +30,7 @@ private slots:
     /* Stadium subview controls */
     void fillStadiumEditFields(StadiumId);
     void on_pushButton_stadConfirmEdit_clicked();
+    void on_pushButton_stadAddFromFile_clicked();
     void on_pushButton_stadEditSouvenirs_clicked();
 
     /* Souvenir subview controls */

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -34,7 +34,6 @@ private slots:
     void on_pushButton_souvHideRestore_clicked();
     void on_pushButton_souvGoBack_clicked();
 
-
 private:
     Ui::AdminView* m_ui;
     int m_currentStadiumId = -1;

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -30,8 +30,10 @@ private slots:
     void on_pushButton_stadEditSouvenirs_clicked();
 
     /* Souvenir subview controls */
-//    void fillSouvenirEditFields(int souvenirId);
+    void fillSouvenirEditFields(int souvenirId);
+    void on_pushButton_souvHideRestore_clicked();
     void on_pushButton_souvGoBack_clicked();
+
 
 private:
     Ui::AdminView* m_ui;

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "view.hpp"
 #include "src/widgets/souvenirlist.hpp"
+#include "src/widgets/stadiumlist.hpp"
 
 namespace Ui
 {
@@ -44,6 +45,7 @@ private:
     StadiumId m_currentStadiumId = -1;
 
     /* Widgets */
+    StadiumList* m_stadiumList;
     SouvenirList* m_availableSouvenirList;
     SouvenirList* m_hiddenSouvenirList;
 };

--- a/src/views/adminview.hpp
+++ b/src/views/adminview.hpp
@@ -24,20 +24,21 @@ public:
 
 private slots:
     void fillStadiumList();
-    void fillSouvenirLists(int stadiumId);
+    void fillSouvenirLists(StadiumId);
+    SouvenirId getCurrentSouvenirId() const;
 
     /* Stadium subview controls */
-    void fillStadiumEditFields(int stadiumId);
+    void fillStadiumEditFields(StadiumId);
     void on_pushButton_stadEditSouvenirs_clicked();
 
     /* Souvenir subview controls */
-    void fillSouvenirEditFields(int souvenirId);
-    void on_pushButton_souvHideRestore_clicked();
-    void on_pushButton_souvGoBack_clicked();
+    void fillSouvenirEditFields(SouvenirId);
+    void on_pushButton_souvConfirmEdit_clicked();
+    void on_pushButton_souvReturn_clicked();
 
 private:
     Ui::AdminView* m_ui;
-    int m_currentStadiumId = -1;
+    StadiumId m_currentStadiumId = -1;
 
     /* Widgets */
     SouvenirList* m_availableSouvenirList;

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -55,9 +55,9 @@
     <widget class="QPushButton" name="pushButton_stadEditSouvenirs">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>70</x>
        <y>570</y>
-       <width>111</width>
+       <width>101</width>
        <height>21</height>
       </rect>
      </property>
@@ -69,7 +69,7 @@
      <property name="geometry">
       <rect>
        <x>20</x>
-       <y>500</y>
+       <y>480</y>
        <width>201</width>
        <height>21</height>
       </rect>
@@ -82,7 +82,7 @@
      <property name="geometry">
       <rect>
        <x>20</x>
-       <y>530</y>
+       <y>510</y>
        <width>201</width>
        <height>21</height>
       </rect>
@@ -95,7 +95,7 @@
      <property name="geometry">
       <rect>
        <x>20</x>
-       <y>560</y>
+       <y>540</y>
        <width>201</width>
        <height>21</height>
       </rect>
@@ -107,14 +107,14 @@
     <widget class="QPushButton" name="pushButton_stadConfirmEdit">
      <property name="geometry">
       <rect>
-       <x>380</x>
+       <x>320</x>
        <y>570</y>
        <width>71</width>
        <height>21</height>
       </rect>
      </property>
      <property name="text">
-      <string>Confirm</string>
+      <string>Save edit</string>
      </property>
     </widget>
     <widget class="QSpinBox" name="spinBox_stadSeatCap">
@@ -564,7 +564,7 @@ QListWidget { background-color: #303030; }</string>
       </rect>
      </property>
      <property name="text">
-      <string>Confirm</string>
+      <string>Add souvenir</string>
      </property>
     </widget>
     <widget class="QLabel" name="label_souvAddInfo">
@@ -628,7 +628,7 @@ QListWidget { background-color: #303030; }</string>
       </rect>
      </property>
      <property name="text">
-      <string>Confirm</string>
+      <string>Save edit</string>
      </property>
     </widget>
     <widget class="QDoubleSpinBox" name="doubleSpinBox_souvEditPrice">

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -23,7 +23,7 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>1</number>
    </property>
    <widget class="QWidget" name="page_stadiums">
     <widget class="QWidget" name="widget_stadList" native="true">
@@ -55,8 +55,8 @@
     <widget class="QPushButton" name="pushButton_stadEditSouvenirs">
      <property name="geometry">
       <rect>
-       <x>300</x>
-       <y>430</y>
+       <x>500</x>
+       <y>570</y>
        <width>111</width>
        <height>21</height>
       </rect>
@@ -133,9 +133,9 @@
     <widget class="QPushButton" name="pushButton_stadConfirmEdit">
      <property name="geometry">
       <rect>
-       <x>560</x>
+       <x>620</x>
        <y>570</y>
-       <width>91</width>
+       <width>71</width>
        <height>21</height>
       </rect>
      </property>
@@ -286,11 +286,14 @@
     <widget class="QLabel" name="label_stadEditInfo">
      <property name="geometry">
       <rect>
-       <x>260</x>
-       <y>480</y>
-       <width>191</width>
-       <height>16</height>
+       <x>230</x>
+       <y>469</y>
+       <width>251</width>
+       <height>31</height>
       </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLabel { font-size: 15px; }</string>
      </property>
      <property name="text">
       <string>Select a stadium from the list to edit</string>
@@ -352,10 +355,10 @@
     <widget class="QWidget" name="widget_souvAvailableList" native="true">
      <property name="geometry">
       <rect>
-       <x>70</x>
-       <y>60</y>
+       <x>90</x>
+       <y>90</y>
        <width>220</width>
-       <height>321</height>
+       <height>361</height>
       </rect>
      </property>
      <property name="styleSheet">
@@ -365,47 +368,34 @@
     <widget class="QWidget" name="widget_souvHiddenList" native="true">
      <property name="geometry">
       <rect>
-       <x>420</x>
-       <y>60</y>
+       <x>400</x>
+       <y>90</y>
        <width>220</width>
-       <height>321</height>
+       <height>361</height>
       </rect>
      </property>
      <property name="styleSheet">
       <string notr="true">QWidget { background-color: red; }</string>
      </property>
     </widget>
-    <widget class="QPushButton" name="pushButton_souvHide">
-     <property name="geometry">
-      <rect>
-       <x>140</x>
-       <y>390</y>
-       <width>80</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Hide</string>
-     </property>
-    </widget>
     <widget class="QPushButton" name="pushButton_souvRestore">
      <property name="geometry">
       <rect>
-       <x>490</x>
-       <y>390</y>
-       <width>80</width>
+       <x>310</x>
+       <y>460</y>
+       <width>91</width>
        <height>21</height>
       </rect>
      </property>
      <property name="text">
-      <string>Restore</string>
+      <string>Hide/Restore</string>
      </property>
     </widget>
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="label_souvAvailableListInfo">
      <property name="geometry">
       <rect>
-       <x>70</x>
-       <y>20</y>
+       <x>90</x>
+       <y>50</y>
        <width>221</width>
        <height>41</height>
       </rect>
@@ -420,11 +410,11 @@
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="label_souvHiddenListInfo">
      <property name="geometry">
       <rect>
-       <x>420</x>
-       <y>20</y>
+       <x>400</x>
+       <y>50</y>
        <width>221</width>
        <height>41</height>
       </rect>
@@ -439,27 +429,133 @@
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
-    <widget class="QLabel" name="label_4">
+    <widget class="QLineEdit" name="lineEdit_souvAddName">
      <property name="geometry">
       <rect>
-       <x>90</x>
-       <y>500</y>
-       <width>47</width>
-       <height>13</height>
+       <x>100</x>
+       <y>530</y>
+       <width>161</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="placeholderText">
+      <string>name</string>
+     </property>
+    </widget>
+    <widget class="QDoubleSpinBox" name="doubleSpinBox_souvAddPrice">
+     <property name="geometry">
+      <rect>
+       <x>100</x>
+       <y>560</y>
+       <width>71</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <property name="prefix">
+      <string>$</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="pushButton_souvConfirmAdd">
+     <property name="geometry">
+      <rect>
+       <x>180</x>
+       <y>560</y>
+       <width>80</width>
+       <height>21</height>
       </rect>
      </property>
      <property name="text">
-      <string>TextLabel</string>
+      <string>Confirm</string>
      </property>
     </widget>
-    <widget class="QLineEdit" name="lineEdit">
+    <widget class="QLabel" name="label_souvAddInfo">
      <property name="geometry">
       <rect>
-       <x>80</x>
-       <y>520</y>
-       <width>113</width>
+       <x>100</x>
+       <y>500</y>
+       <width>161</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLabel { font-size: 20px; }</string>
+     </property>
+     <property name="text">
+      <string>Add souvenir</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_souvEditInfo">
+     <property name="geometry">
+      <rect>
+       <x>450</x>
+       <y>499</y>
+       <width>161</width>
        <height>21</height>
       </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLabel { font-size: 20px; }</string>
+     </property>
+     <property name="text">
+      <string>Edit souvenir</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="lineEdit_souvEditName">
+     <property name="geometry">
+      <rect>
+       <x>450</x>
+       <y>530</y>
+       <width>161</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="placeholderText">
+      <string>name</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="pushButton_souvConfirmEdit">
+     <property name="geometry">
+      <rect>
+       <x>530</x>
+       <y>560</y>
+       <width>80</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Confirm</string>
+     </property>
+    </widget>
+    <widget class="QDoubleSpinBox" name="doubleSpinBox_souvEditPrice">
+     <property name="geometry">
+      <rect>
+       <x>450</x>
+       <y>560</y>
+       <width>71</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <property name="prefix">
+      <string>$</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="pushButton_souvRestore_2">
+     <property name="geometry">
+      <rect>
+       <x>310</x>
+       <y>490</y>
+       <width>91</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Go back...</string>
      </property>
     </widget>
    </widget>

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -36,7 +36,11 @@
       </rect>
      </property>
      <property name="styleSheet">
-      <string notr="true">QWidget { background-color: red; }</string>
+      <string notr="true">QTreeWidget
+{
+	color: white;
+	background-color: #303030;
+}</string>
      </property>
     </widget>
     <widget class="QPushButton" name="pushButton_stadAddFromFile">
@@ -432,19 +436,6 @@
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QSpinBox" name="spinBox">
-     <property name="geometry">
-      <rect>
-       <x>60</x>
-       <y>420</y>
-       <width>43</width>
-       <height>22</height>
-      </rect>
-     </property>
-     <property name="minimum">
-      <number>-99</number>
      </property>
     </widget>
    </widget>

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -126,6 +126,9 @@
        <height>22</height>
       </rect>
      </property>
+     <property name="maximum">
+      <number>1000000</number>
+     </property>
     </widget>
     <widget class="QSpinBox" name="spinBox_stadCenterDist">
      <property name="geometry">
@@ -138,6 +141,9 @@
      </property>
      <property name="suffix">
       <string>ft</string>
+     </property>
+     <property name="maximum">
+      <number>1000</number>
      </property>
     </widget>
     <widget class="QLabel" name="label_stadSeatCapInfo">
@@ -426,6 +432,16 @@
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QSpinBox" name="spinBox">
+     <property name="geometry">
+      <rect>
+       <x>60</x>
+       <y>420</y>
+       <width>43</width>
+       <height>22</height>
+      </rect>
      </property>
     </widget>
    </widget>

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -1,0 +1,470 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AdminView</class>
+ <widget class="QWidget" name="AdminView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>710</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QStackedWidget" name="stackedWidget">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>711</width>
+     <height>601</height>
+    </rect>
+   </property>
+   <property name="currentIndex">
+    <number>0</number>
+   </property>
+   <widget class="QWidget" name="page_stadiums">
+    <widget class="QWidget" name="widget_stadList" native="true">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>10</y>
+       <width>691</width>
+       <height>381</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QWidget { background-color: red; }</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="pushButton_stadAddFromFile">
+     <property name="geometry">
+      <rect>
+       <x>290</x>
+       <y>400</y>
+       <width>131</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Add stadiums from file...</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="pushButton_stadEditSouvenirs">
+     <property name="geometry">
+      <rect>
+       <x>300</x>
+       <y>430</y>
+       <width>111</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Edit souvenirs...</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="lineEdit_stadName">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>510</y>
+       <width>113</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="placeholderText">
+      <string>stadium name</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="lineEdit_stadLocation">
+     <property name="geometry">
+      <rect>
+       <x>140</x>
+       <y>510</y>
+       <width>113</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="placeholderText">
+      <string>location</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="lineEdit_stadYearOpened">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>570</y>
+       <width>113</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="placeholderText">
+      <string>year opened</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="lineEdit_stadTeamName">
+     <property name="geometry">
+      <rect>
+       <x>20</x>
+       <y>540</y>
+       <width>113</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="placeholderText">
+      <string>team name</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="lineEdit_stadTeamLeague">
+     <property name="geometry">
+      <rect>
+       <x>140</x>
+       <y>540</y>
+       <width>113</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="placeholderText">
+      <string>team league</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="pushButton_stadConfirmEdit">
+     <property name="geometry">
+      <rect>
+       <x>560</x>
+       <y>570</y>
+       <width>91</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Confirm</string>
+     </property>
+    </widget>
+    <widget class="QSpinBox" name="spinBox_stadSeatCap">
+     <property name="geometry">
+      <rect>
+       <x>630</x>
+       <y>510</y>
+       <width>61</width>
+       <height>22</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QSpinBox" name="spinBox_stadCenterDist">
+     <property name="geometry">
+      <rect>
+       <x>630</x>
+       <y>540</y>
+       <width>61</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <property name="suffix">
+      <string>ft</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_stadSeatCapInfo">
+     <property name="geometry">
+      <rect>
+       <x>510</x>
+       <y>510</y>
+       <width>111</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Seating capacity</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_stadCenterDistInfo">
+     <property name="geometry">
+      <rect>
+       <x>510</x>
+       <y>540</y>
+       <width>111</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Center field distance</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="comboBox_stadRoof">
+     <property name="geometry">
+      <rect>
+       <x>360</x>
+       <y>510</y>
+       <width>111</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <item>
+      <property name="text">
+       <string>Retractable</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Open</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Fixed</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QComboBox" name="comboBox_stadSurface">
+     <property name="geometry">
+      <rect>
+       <x>360</x>
+       <y>540</y>
+       <width>111</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <item>
+      <property name="text">
+       <string>Grass</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>AstroTurf GameDay Grass</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QComboBox" name="comboBox_stadTypology">
+     <property name="geometry">
+      <rect>
+       <x>360</x>
+       <y>570</y>
+       <width>111</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <item>
+      <property name="text">
+       <string>Retro Modern</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Retro Classic</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Jewel Box</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Modern</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Contemporary</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Multipurpose</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QLabel" name="label_stadEditInfo">
+     <property name="geometry">
+      <rect>
+       <x>260</x>
+       <y>480</y>
+       <width>191</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Select a stadium from the list to edit</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_stadRoofInfo">
+     <property name="geometry">
+      <rect>
+       <x>270</x>
+       <y>510</y>
+       <width>81</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Roof type</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_stadSurfaceInfo">
+     <property name="geometry">
+      <rect>
+       <x>270</x>
+       <y>540</y>
+       <width>81</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Surface type</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_stadTypologyInfo">
+     <property name="geometry">
+      <rect>
+       <x>270</x>
+       <y>570</y>
+       <width>81</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Typology type</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </widget>
+   <widget class="QWidget" name="page_souvenirs">
+    <widget class="QWidget" name="widget_souvAvailableList" native="true">
+     <property name="geometry">
+      <rect>
+       <x>70</x>
+       <y>60</y>
+       <width>220</width>
+       <height>321</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QWidget {background-color: red; }</string>
+     </property>
+    </widget>
+    <widget class="QWidget" name="widget_souvHiddenList" native="true">
+     <property name="geometry">
+      <rect>
+       <x>420</x>
+       <y>60</y>
+       <width>220</width>
+       <height>321</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QWidget { background-color: red; }</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="pushButton_souvHide">
+     <property name="geometry">
+      <rect>
+       <x>140</x>
+       <y>390</y>
+       <width>80</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Hide</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="pushButton_souvRestore">
+     <property name="geometry">
+      <rect>
+       <x>490</x>
+       <y>390</y>
+       <width>80</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Restore</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_2">
+     <property name="geometry">
+      <rect>
+       <x>70</x>
+       <y>20</y>
+       <width>221</width>
+       <height>41</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLabel { font-size: 20px; }</string>
+     </property>
+     <property name="text">
+      <string>Available Souvenirs</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_3">
+     <property name="geometry">
+      <rect>
+       <x>420</x>
+       <y>20</y>
+       <width>221</width>
+       <height>41</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLabel { font-size: 20px; }</string>
+     </property>
+     <property name="text">
+      <string>Hidden Souvenirs</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_4">
+     <property name="geometry">
+      <rect>
+       <x>90</x>
+       <y>500</y>
+       <width>47</width>
+       <height>13</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="lineEdit">
+     <property name="geometry">
+      <rect>
+       <x>80</x>
+       <y>520</y>
+       <width>113</width>
+       <height>21</height>
+      </rect>
+     </property>
+    </widget>
+   </widget>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -350,6 +350,22 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
+    <widget class="QLabel" name="label_stadAddInfo">
+     <property name="geometry">
+      <rect>
+       <x>430</x>
+       <y>400</y>
+       <width>271</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>Requires 2 files: stadium info and  map coordinates</string>
+     </property>
+    </widget>
    </widget>
    <widget class="QWidget" name="page_souvenirs">
     <widget class="QWidget" name="widget_souvAvailableList" native="true">

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -23,7 +23,7 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>1</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="page_stadiums">
     <widget class="QWidget" name="widget_stadList" native="true">
@@ -545,7 +545,7 @@
       <string>$</string>
      </property>
     </widget>
-    <widget class="QPushButton" name="pushButton_souvRestore_2">
+    <widget class="QPushButton" name="pushButton_souvGoBack">
      <property name="geometry">
       <rect>
        <x>310</x>

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -23,7 +23,7 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>1</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="page_stadiums">
     <widget class="QWidget" name="widget_stadList" native="true">
@@ -442,6 +442,9 @@
        <width>43</width>
        <height>22</height>
       </rect>
+     </property>
+     <property name="minimum">
+      <number>-99</number>
      </property>
     </widget>
    </widget>

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -107,14 +107,14 @@
     <widget class="QPushButton" name="pushButton_stadConfirmEdit">
      <property name="geometry">
       <rect>
-       <x>320</x>
+       <x>300</x>
        <y>570</y>
-       <width>71</width>
+       <width>111</width>
        <height>21</height>
       </rect>
      </property>
      <property name="text">
-      <string>Save edit</string>
+      <string>Save edit changes</string>
      </property>
     </widget>
     <widget class="QSpinBox" name="spinBox_stadSeatCap">
@@ -477,19 +477,6 @@ QListWidget { background-color: #303030; }</string>
 QListWidget { background-color: #303030; }</string>
      </property>
     </widget>
-    <widget class="QPushButton" name="pushButton_souvHideRestore">
-     <property name="geometry">
-      <rect>
-       <x>310</x>
-       <y>460</y>
-       <width>91</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Hide/Restore</string>
-     </property>
-    </widget>
     <widget class="QLabel" name="label_souvAvailableListInfo">
      <property name="geometry">
       <rect>
@@ -532,7 +519,7 @@ QListWidget { background-color: #303030; }</string>
      <property name="geometry">
       <rect>
        <x>110</x>
-       <y>530</y>
+       <y>510</y>
        <width>161</width>
        <height>21</height>
       </rect>
@@ -545,7 +532,7 @@ QListWidget { background-color: #303030; }</string>
      <property name="geometry">
       <rect>
        <x>110</x>
-       <y>560</y>
+       <y>540</y>
        <width>71</width>
        <height>22</height>
       </rect>
@@ -557,27 +544,27 @@ QListWidget { background-color: #303030; }</string>
     <widget class="QPushButton" name="pushButton_souvConfirmAdd">
      <property name="geometry">
       <rect>
-       <x>190</x>
-       <y>560</y>
-       <width>80</width>
+       <x>130</x>
+       <y>570</y>
+       <width>121</width>
        <height>21</height>
       </rect>
      </property>
      <property name="text">
-      <string>Add souvenir</string>
+      <string>Confirm new souvenir</string>
      </property>
     </widget>
     <widget class="QLabel" name="label_souvAddInfo">
      <property name="geometry">
       <rect>
        <x>110</x>
-       <y>500</y>
+       <y>480</y>
        <width>161</width>
        <height>20</height>
       </rect>
      </property>
      <property name="styleSheet">
-      <string notr="true">QLabel { font-size: 20px; }</string>
+      <string notr="true">QLabel { font-size: 15px; }</string>
      </property>
      <property name="text">
       <string>Add souvenir</string>
@@ -590,13 +577,13 @@ QListWidget { background-color: #303030; }</string>
      <property name="geometry">
       <rect>
        <x>440</x>
-       <y>500</y>
+       <y>480</y>
        <width>161</width>
        <height>21</height>
       </rect>
      </property>
      <property name="styleSheet">
-      <string notr="true">QLabel { font-size: 20px; }</string>
+      <string notr="true">QLabel { font-size: 15px; }</string>
      </property>
      <property name="text">
       <string>Edit souvenir</string>
@@ -609,7 +596,7 @@ QListWidget { background-color: #303030; }</string>
      <property name="geometry">
       <rect>
        <x>440</x>
-       <y>530</y>
+       <y>510</y>
        <width>161</width>
        <height>21</height>
       </rect>
@@ -621,21 +608,21 @@ QListWidget { background-color: #303030; }</string>
     <widget class="QPushButton" name="pushButton_souvConfirmEdit">
      <property name="geometry">
       <rect>
-       <x>520</x>
-       <y>560</y>
-       <width>80</width>
+       <x>460</x>
+       <y>570</y>
+       <width>121</width>
        <height>21</height>
       </rect>
      </property>
      <property name="text">
-      <string>Save edit</string>
+      <string>Save edit changes</string>
      </property>
     </widget>
     <widget class="QDoubleSpinBox" name="doubleSpinBox_souvEditPrice">
      <property name="geometry">
       <rect>
        <x>440</x>
-       <y>560</y>
+       <y>540</y>
        <width>71</width>
        <height>22</height>
       </rect>
@@ -644,17 +631,43 @@ QListWidget { background-color: #303030; }</string>
       <string>$</string>
      </property>
     </widget>
-    <widget class="QPushButton" name="pushButton_souvGoBack">
+    <widget class="QPushButton" name="pushButton_souvReturn">
      <property name="geometry">
       <rect>
        <x>310</x>
-       <y>490</y>
+       <y>570</y>
        <width>91</width>
        <height>21</height>
       </rect>
      </property>
      <property name="text">
-      <string>Go back...</string>
+      <string>Return...</string>
+     </property>
+    </widget>
+    <widget class="QCheckBox" name="checkBox_souvEditHidden">
+     <property name="geometry">
+      <rect>
+       <x>540</x>
+       <y>540</y>
+       <width>61</width>
+       <height>19</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Hidden</string>
+     </property>
+    </widget>
+    <widget class="QCheckBox" name="checkBox_souvAddHidden">
+     <property name="geometry">
+      <rect>
+       <x>210</x>
+       <y>540</y>
+       <width>61</width>
+       <height>19</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Hidden</string>
      </property>
     </widget>
    </widget>

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -23,7 +23,7 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>1</number>
    </property>
    <widget class="QWidget" name="page_stadiums">
     <widget class="QWidget" name="widget_stadList" native="true">
@@ -474,7 +474,7 @@ QListWidget { background-color: #303030; }</string>
 QListWidget { background-color: #303030; }</string>
      </property>
     </widget>
-    <widget class="QPushButton" name="pushButton_souvRestore">
+    <widget class="QPushButton" name="pushButton_souvHideRestore">
      <property name="geometry">
       <rect>
        <x>310</x>

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -23,7 +23,7 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>1</number>
    </property>
    <widget class="QWidget" name="page_stadiums">
     <widget class="QWidget" name="widget_stadList" native="true">

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -23,7 +23,7 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>1</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="page_stadiums">
     <widget class="QWidget" name="widget_stadList" native="true">

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -358,7 +358,7 @@
       <string notr="true"/>
      </property>
      <property name="text">
-      <string>Requires 2 files: stadium info and  map coordinates</string>
+      <string>Requires 2 files: stadium info and distance info</string>
      </property>
     </widget>
     <widget class="QComboBox" name="comboBox_stadTeamLeague">

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -94,8 +94,8 @@
     <widget class="QLineEdit" name="lineEdit_stadYearOpened">
      <property name="geometry">
       <rect>
-       <x>20</x>
-       <y>570</y>
+       <x>140</x>
+       <y>540</y>
        <width>113</width>
        <height>21</height>
       </rect>
@@ -115,19 +115,6 @@
      </property>
      <property name="placeholderText">
       <string>team name</string>
-     </property>
-    </widget>
-    <widget class="QLineEdit" name="lineEdit_stadTeamLeague">
-     <property name="geometry">
-      <rect>
-       <x>140</x>
-       <y>540</y>
-       <width>113</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="placeholderText">
-      <string>team league</string>
      </property>
     </widget>
     <widget class="QPushButton" name="pushButton_stadConfirmEdit">
@@ -209,6 +196,11 @@
      </property>
      <item>
       <property name="text">
+       <string/>
+      </property>
+     </item>
+     <item>
+      <property name="text">
        <string>Retractable</string>
       </property>
      </item>
@@ -234,6 +226,11 @@
      </property>
      <item>
       <property name="text">
+       <string/>
+      </property>
+     </item>
+     <item>
+      <property name="text">
        <string>Grass</string>
       </property>
      </item>
@@ -252,6 +249,11 @@
        <height>22</height>
       </rect>
      </property>
+     <item>
+      <property name="text">
+       <string/>
+      </property>
+     </item>
      <item>
       <property name="text">
        <string>Retro Modern</string>
@@ -366,19 +368,61 @@
       <string>Requires 2 files: stadium info and  map coordinates</string>
      </property>
     </widget>
+    <widget class="QComboBox" name="comboBox_stadTeamLeague">
+     <property name="geometry">
+      <rect>
+       <x>140</x>
+       <y>570</y>
+       <width>111</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <item>
+      <property name="text">
+       <string/>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>National</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>American</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QLabel" name="label_stadTeamLeagueInfo">
+     <property name="geometry">
+      <rect>
+       <x>50</x>
+       <y>570</y>
+       <width>81</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>League type</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
    </widget>
    <widget class="QWidget" name="page_souvenirs">
     <widget class="QWidget" name="widget_souvAvailableList" native="true">
      <property name="geometry">
       <rect>
-       <x>90</x>
+       <x>69</x>
        <y>90</y>
-       <width>220</width>
+       <width>241</width>
        <height>361</height>
       </rect>
      </property>
      <property name="styleSheet">
-      <string notr="true">QWidget {background-color: red; }</string>
+      <string notr="true">QLabel { color: white; }
+QListWidget { background-color: #303030; }</string>
      </property>
     </widget>
     <widget class="QWidget" name="widget_souvHiddenList" native="true">
@@ -386,12 +430,13 @@
       <rect>
        <x>400</x>
        <y>90</y>
-       <width>220</width>
+       <width>241</width>
        <height>361</height>
       </rect>
      </property>
      <property name="styleSheet">
-      <string notr="true">QWidget { background-color: red; }</string>
+      <string notr="true">QLabel { color: white; }
+QListWidget { background-color: #303030; }</string>
      </property>
     </widget>
     <widget class="QPushButton" name="pushButton_souvRestore">
@@ -410,9 +455,9 @@
     <widget class="QLabel" name="label_souvAvailableListInfo">
      <property name="geometry">
       <rect>
-       <x>90</x>
+       <x>70</x>
        <y>50</y>
-       <width>221</width>
+       <width>241</width>
        <height>41</height>
       </rect>
      </property>
@@ -431,7 +476,7 @@
       <rect>
        <x>400</x>
        <y>50</y>
-       <width>221</width>
+       <width>241</width>
        <height>41</height>
       </rect>
      </property>
@@ -448,7 +493,7 @@
     <widget class="QLineEdit" name="lineEdit_souvAddName">
      <property name="geometry">
       <rect>
-       <x>100</x>
+       <x>110</x>
        <y>530</y>
        <width>161</width>
        <height>21</height>
@@ -461,7 +506,7 @@
     <widget class="QDoubleSpinBox" name="doubleSpinBox_souvAddPrice">
      <property name="geometry">
       <rect>
-       <x>100</x>
+       <x>110</x>
        <y>560</y>
        <width>71</width>
        <height>22</height>
@@ -474,7 +519,7 @@
     <widget class="QPushButton" name="pushButton_souvConfirmAdd">
      <property name="geometry">
       <rect>
-       <x>180</x>
+       <x>190</x>
        <y>560</y>
        <width>80</width>
        <height>21</height>
@@ -487,7 +532,7 @@
     <widget class="QLabel" name="label_souvAddInfo">
      <property name="geometry">
       <rect>
-       <x>100</x>
+       <x>110</x>
        <y>500</y>
        <width>161</width>
        <height>20</height>
@@ -506,8 +551,8 @@
     <widget class="QLabel" name="label_souvEditInfo">
      <property name="geometry">
       <rect>
-       <x>450</x>
-       <y>499</y>
+       <x>440</x>
+       <y>500</y>
        <width>161</width>
        <height>21</height>
       </rect>
@@ -525,7 +570,7 @@
     <widget class="QLineEdit" name="lineEdit_souvEditName">
      <property name="geometry">
       <rect>
-       <x>450</x>
+       <x>440</x>
        <y>530</y>
        <width>161</width>
        <height>21</height>
@@ -538,7 +583,7 @@
     <widget class="QPushButton" name="pushButton_souvConfirmEdit">
      <property name="geometry">
       <rect>
-       <x>530</x>
+       <x>520</x>
        <y>560</y>
        <width>80</width>
        <height>21</height>
@@ -551,7 +596,7 @@
     <widget class="QDoubleSpinBox" name="doubleSpinBox_souvEditPrice">
      <property name="geometry">
       <rect>
-       <x>450</x>
+       <x>440</x>
        <y>560</y>
        <width>71</width>
        <height>22</height>

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -418,7 +418,7 @@
       <number>2100</number>
      </property>
     </widget>
-    <widget class="QLabel" name="label_stadCenterDistInfo_2">
+    <widget class="QLabel" name="label_stadYearOpenedInfo">
      <property name="geometry">
       <rect>
        <x>270</x>

--- a/src/views/adminview.ui
+++ b/src/views/adminview.ui
@@ -55,7 +55,7 @@
     <widget class="QPushButton" name="pushButton_stadEditSouvenirs">
      <property name="geometry">
       <rect>
-       <x>500</x>
+       <x>260</x>
        <y>570</y>
        <width>111</width>
        <height>21</height>
@@ -69,8 +69,8 @@
      <property name="geometry">
       <rect>
        <x>20</x>
-       <y>510</y>
-       <width>113</width>
+       <y>500</y>
+       <width>201</width>
        <height>21</height>
       </rect>
      </property>
@@ -81,9 +81,9 @@
     <widget class="QLineEdit" name="lineEdit_stadLocation">
      <property name="geometry">
       <rect>
-       <x>140</x>
-       <y>510</y>
-       <width>113</width>
+       <x>20</x>
+       <y>530</y>
+       <width>201</width>
        <height>21</height>
       </rect>
      </property>
@@ -91,25 +91,12 @@
       <string>location</string>
      </property>
     </widget>
-    <widget class="QLineEdit" name="lineEdit_stadYearOpened">
-     <property name="geometry">
-      <rect>
-       <x>140</x>
-       <y>540</y>
-       <width>113</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="placeholderText">
-      <string>year opened</string>
-     </property>
-    </widget>
     <widget class="QLineEdit" name="lineEdit_stadTeamName">
      <property name="geometry">
       <rect>
        <x>20</x>
-       <y>540</y>
-       <width>113</width>
+       <y>560</y>
+       <width>201</width>
        <height>21</height>
       </rect>
      </property>
@@ -120,7 +107,7 @@
     <widget class="QPushButton" name="pushButton_stadConfirmEdit">
      <property name="geometry">
       <rect>
-       <x>620</x>
+       <x>380</x>
        <y>570</y>
        <width>71</width>
        <height>21</height>
@@ -133,7 +120,7 @@
     <widget class="QSpinBox" name="spinBox_stadSeatCap">
      <property name="geometry">
       <rect>
-       <x>630</x>
+       <x>380</x>
        <y>510</y>
        <width>61</width>
        <height>22</height>
@@ -143,7 +130,7 @@
     <widget class="QSpinBox" name="spinBox_stadCenterDist">
      <property name="geometry">
       <rect>
-       <x>630</x>
+       <x>380</x>
        <y>540</y>
        <width>61</width>
        <height>22</height>
@@ -156,9 +143,9 @@
     <widget class="QLabel" name="label_stadSeatCapInfo">
      <property name="geometry">
       <rect>
-       <x>510</x>
+       <x>270</x>
        <y>510</y>
-       <width>111</width>
+       <width>101</width>
        <height>21</height>
       </rect>
      </property>
@@ -172,9 +159,9 @@
     <widget class="QLabel" name="label_stadCenterDistInfo">
      <property name="geometry">
       <rect>
-       <x>510</x>
+       <x>270</x>
        <y>540</y>
-       <width>111</width>
+       <width>101</width>
        <height>21</height>
       </rect>
      </property>
@@ -188,9 +175,9 @@
     <widget class="QComboBox" name="comboBox_stadRoof">
      <property name="geometry">
       <rect>
-       <x>360</x>
+       <x>550</x>
        <y>510</y>
-       <width>111</width>
+       <width>151</width>
        <height>22</height>
       </rect>
      </property>
@@ -218,9 +205,9 @@
     <widget class="QComboBox" name="comboBox_stadSurface">
      <property name="geometry">
       <rect>
-       <x>360</x>
+       <x>550</x>
        <y>540</y>
-       <width>111</width>
+       <width>151</width>
        <height>22</height>
       </rect>
      </property>
@@ -243,9 +230,9 @@
     <widget class="QComboBox" name="comboBox_stadTypology">
      <property name="geometry">
       <rect>
-       <x>360</x>
+       <x>550</x>
        <y>570</y>
-       <width>111</width>
+       <width>151</width>
        <height>22</height>
       </rect>
      </property>
@@ -289,7 +276,7 @@
      <property name="geometry">
       <rect>
        <x>230</x>
-       <y>469</y>
+       <y>450</y>
        <width>251</width>
        <height>31</height>
       </rect>
@@ -307,9 +294,9 @@
     <widget class="QLabel" name="label_stadRoofInfo">
      <property name="geometry">
       <rect>
-       <x>270</x>
+       <x>470</x>
        <y>510</y>
-       <width>81</width>
+       <width>71</width>
        <height>21</height>
       </rect>
      </property>
@@ -323,9 +310,9 @@
     <widget class="QLabel" name="label_stadSurfaceInfo">
      <property name="geometry">
       <rect>
-       <x>270</x>
+       <x>470</x>
        <y>540</y>
-       <width>81</width>
+       <width>71</width>
        <height>21</height>
       </rect>
      </property>
@@ -339,9 +326,9 @@
     <widget class="QLabel" name="label_stadTypologyInfo">
      <property name="geometry">
       <rect>
-       <x>270</x>
+       <x>470</x>
        <y>570</y>
-       <width>81</width>
+       <width>71</width>
        <height>21</height>
       </rect>
      </property>
@@ -371,9 +358,9 @@
     <widget class="QComboBox" name="comboBox_stadTeamLeague">
      <property name="geometry">
       <rect>
-       <x>140</x>
-       <y>570</y>
-       <width>111</width>
+       <x>550</x>
+       <y>480</y>
+       <width>151</width>
        <height>22</height>
       </rect>
      </property>
@@ -396,14 +383,46 @@
     <widget class="QLabel" name="label_stadTeamLeagueInfo">
      <property name="geometry">
       <rect>
-       <x>50</x>
-       <y>570</y>
-       <width>81</width>
+       <x>470</x>
+       <y>480</y>
+       <width>71</width>
        <height>21</height>
       </rect>
      </property>
      <property name="text">
       <string>League type</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QSpinBox" name="spinBox_stadYearOpened">
+     <property name="geometry">
+      <rect>
+       <x>380</x>
+       <y>480</y>
+       <width>61</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <property name="minimum">
+      <number>1839</number>
+     </property>
+     <property name="maximum">
+      <number>2100</number>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_stadCenterDistInfo_2">
+     <property name="geometry">
+      <rect>
+       <x>270</x>
+       <y>480</y>
+       <width>101</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Year opened</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/windows/mainwindow.cpp
+++ b/src/windows/mainwindow.cpp
@@ -2,6 +2,7 @@
 #include "ui_mainwindow.h"
 #include "src/windows/login.hpp"
 #include "src/datastore/database.hpp"
+#include "src/views/adminview.hpp"
 #include <QFontDatabase>
 #include <QMessageBox>
 #include <QDebug>
@@ -29,9 +30,11 @@ MainWindow::MainWindow()
         m_navbar->addItem("\uf085", "Inventory\nManagement");
     m_navbar->addItem("\uf2f5", "Logout");
 
-    Database::loadFromFile("./../../../src/datastore/MLBInformation.csv");
+    Database::loadDistancesFromFile("DistanceBetweenStadiums.csv");
+    Database::loadFromFile("MLBInformation.csv");
 
-    //m_views.push_back(new AdminView(m_ui->adminView));
+    /* Create views */
+    m_views.push_back(new AdminView(m_ui->adminView));
     m_views.push_back(new StadiumView(m_ui->viewTeamView));
 }
 
@@ -70,5 +73,5 @@ void MainWindow::changeView(int view)
 void MainWindow::resetViews()
 {
     /* Reset views -- go here */
-    Database::saveToFile("./../../../src/datastore/MLBInformation.csv");
+    Database::saveToFile("MLBInformation.csv");
 }

--- a/src/windows/mainwindow.cpp
+++ b/src/windows/mainwindow.cpp
@@ -7,6 +7,7 @@
 #include <QMessageBox>
 #include <QDebug>
 #include "src/views/stadiumview.hpp"
+#include <algorithm>
 
 /* Constructors */
 MainWindow::MainWindow()
@@ -74,4 +75,8 @@ void MainWindow::resetViews()
 {
     /* Reset views -- go here */
     Database::saveToFile("MLBInformation.csv");
+
+    //Reset each view
+    std::for_each(m_views.begin(), m_views.end(),
+                  [](View* view){view->resetView();});
 }

--- a/src/windows/mainwindow.hpp
+++ b/src/windows/mainwindow.hpp
@@ -1,6 +1,6 @@
 #pragma once
-
 #include <QMainWindow>
+#include <vector>
 #include "src/widgets/navbar.hpp"
 #include "src/views/view.hpp"
 

--- a/src/windows/mainwindow.ui
+++ b/src/windows/mainwindow.ui
@@ -130,21 +130,7 @@ background-color: white;
       </property>
      </widget>
     </widget>
-    <widget class="QWidget" name="adminView">
-     <widget class="QLabel" name="label_4">
-      <property name="geometry">
-       <rect>
-        <x>90</x>
-        <y>50</y>
-        <width>101</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>admin view</string>
-      </property>
-     </widget>
-    </widget>
+    <widget class="QWidget" name="adminView"/>
    </widget>
   </widget>
  </widget>


### PR DESCRIPTION
Closes #20 

### Key features
* Display stadiums in a list
* When stadium is clicked, information about it is editable
* When stadium is clicked, able to enter souvenir editor page
* Display available and hidden souvenirs in lists
* When souvenir is clicked, information about it is editable
* Able to add souvenirs through input fields
* Able to add stadiums and their distances to other stadiums through file dialogs
* If invalid input occurred, the respective button's text turns red and is reset after 2 seconds

### Future Improvements
* Change how adding stadiums and their distances work (multiple buttons for dialogs)

### Notes
Adding stadiums requires prompting two file dialogs.