### PR TITLE
fixed off by 1 size error after readding after removal

### DIFF
--- a/app/src/utils/map.hpp
+++ b/app/src/utils/map.hpp
@@ -601,6 +601,7 @@ namespace nstd
     {
         int findPosition = -1;
         node* found = insertFind(k, findPosition);
+        if(found != NULL && found->available) ++m_numOfElems;
         if(found != NULL) found->available = false;
         node* tmp;
         unsigned int hashCode = 0;

--- a/tests/map_test/map_test.cpp
+++ b/tests/map_test/map_test.cpp
@@ -78,6 +78,16 @@ void map_test::testLoadData()
     QCOMPARE("harro", *m_map.find(-1));
     QCOMPARE("hi", *m_map.find(1));
     QCOMPARE("hi", *m_map.find(2));
+
+    /*
+     * making sure same hash doesn't overrwrite and make sure elems
+     * are counted properly
+     */
+    m_map.remove(-1);
+    QCOMPARE("hi", *m_map.find(1));
+    m_map[-1] = "ho";
+    QCOMPARE("ho", *m_map.find(-1));
+
 }
 
 void map_test::testIterator()


### PR DESCRIPTION
Closes #(issue)
N/A

### Key features
* fixed a counting error in map, after removal from map then reading back with the same key.
* Added a test for that case in the unit test for map now

### Future Improvements
* any other bugs, if present, will be dealt with at that time

### Notes
This bug had no significance in any of the code so far. So it will not effect anything.
So really it was just something the unit test picked up. Other than that looking good boys.