### PR TITLE
Receipt resize

### DIFF
--- a/app/src/views/receiptview.cpp
+++ b/app/src/views/receiptview.cpp
@@ -7,17 +7,6 @@ ReceiptView::ReceiptView(QWidget* parent)
 {
     m_ui->setupUi(this);
     m_receipt = new ReceiptList(m_ui->ReceiptWidget);
-
-    connect(m_receipt,&QListWidget::itemChanged,this,[&](){
-        if(m_receipt->count() >= 10)
-        {
-            m_receipt->resize(430,500);
-        }
-        else
-        {
-            m_receipt->resize(400,500);
-        }
-    });
 }
 
 /* Destructor */

--- a/app/src/views/receiptview.cpp
+++ b/app/src/views/receiptview.cpp
@@ -7,6 +7,17 @@ ReceiptView::ReceiptView(QWidget* parent)
 {
     m_ui->setupUi(this);
     m_receipt = new ReceiptList(m_ui->ReceiptWidget);
+
+    connect(m_receipt,&QListWidget::itemChanged,this,[&](){
+        if(m_receipt->count() >= 10)
+        {
+            m_receipt->resize(410,500);
+        }
+        else
+        {
+            m_receipt->resize(400,500);
+        }
+    });
 }
 
 /* Destructor */

--- a/app/src/views/receiptview.cpp
+++ b/app/src/views/receiptview.cpp
@@ -11,7 +11,7 @@ ReceiptView::ReceiptView(QWidget* parent)
     connect(m_receipt,&QListWidget::itemChanged,this,[&](){
         if(m_receipt->count() >= 10)
         {
-            m_receipt->resize(410,500);
+            m_receipt->resize(430,500);
         }
         else
         {

--- a/app/src/views/receiptview.ui
+++ b/app/src/views/receiptview.ui
@@ -34,7 +34,7 @@ background-color: #303030;
     <rect>
      <x>110</x>
      <y>50</y>
-     <width>400</width>
+     <width>404</width>
      <height>500</height>
     </rect>
    </property>

--- a/app/src/widgets/receiptlist.cpp
+++ b/app/src/widgets/receiptlist.cpp
@@ -16,7 +16,7 @@ ReceiptList::ReceiptList(QWidget* parent)
 {
     /* List widget settings */
     QListWidget::setStyleSheet("QListWidget { background-color: #303030; color: white; }");
-    QListWidget::resize(parent->size());
+    QListWidget::resize(QSize(420,500));
     QListWidget::setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     QListWidget::setUniformItemSizes(true);
     QListWidget::setWrapping(false);


### PR DESCRIPTION
Closes #(issue)

### Key features
* Make the`ReceiptList`s parent widget resize when it holds 10 items or more to avoid vertical and horizontal scroll bars

### Future Improvements
* none

### Notes
