### PR TITLE
Wrap database functions in try-catch when adding data

### DIFF
--- a/app/src/views/adminview.cpp
+++ b/app/src/views/adminview.cpp
@@ -1,6 +1,7 @@
 #include "adminview.hpp"
 #include "ui_adminview.h"
 #include "src/datastore/database.hpp"
+#include "src/utils/exceptions.hpp"
 #include <QFileDialog>
 #include <QTimer>
 
@@ -314,9 +315,16 @@ void AdminView::on_pushButton_stadAddFromFile_clicked()
         return;
     }
 
-    /* Use the files to load data into the database */
-    Database::loadFromFile(stadFile.toStdString());
-    Database::loadDistancesFromFile(distFile.toStdString());
+    try
+    {
+        /* Use the files to load data into the database */
+        Database::loadFromFile(stadFile.toStdString());
+        Database::loadDistancesFromFile(distFile.toStdString());
+    }
+    catch(...)
+    {
+        GeneralException("An error has occurred when using the files provided").errorWindow();
+    }
 }
 
 /**

--- a/app/src/views/adminview.cpp
+++ b/app/src/views/adminview.cpp
@@ -325,6 +325,8 @@ void AdminView::on_pushButton_stadAddFromFile_clicked()
     {
         GeneralException("An error has occurred when using the files provided").errorWindow();
     }
+
+    resetUi();
 }
 
 /**


### PR DESCRIPTION
### Key features
* Attempt to fix a bug where inputting invalid files would crash the program
* Reset UI when files are added

### Future Improvements
* Actually fix the bug (see notes)

### Notes
The functions being wrapped sometimes doesn't throw anything when an error happens (`std::stoi` is probably the cause here). There are three possibilities when I was testing: an exception is thrown and caught (good), no exception was thrown and program continues execution (eh), or the program crashes (bad).